### PR TITLE
added SkipValidators tag handler

### DIFF
--- a/src/main/java/org/omnifaces/taghandler/SkipValidators.java
+++ b/src/main/java/org/omnifaces/taghandler/SkipValidators.java
@@ -1,0 +1,137 @@
+package org.omnifaces.taghandler;
+
+import java.io.IOException;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UIInput;
+import javax.faces.event.AbortProcessingException;
+import javax.faces.event.ComponentSystemEvent;
+import javax.faces.event.ComponentSystemEventListener;
+import javax.faces.event.PostAddToViewEvent;
+import javax.faces.event.PostValidateEvent;
+import javax.faces.event.PreValidateEvent;
+import javax.faces.event.SystemEvent;
+import javax.faces.event.SystemEventListener;
+import javax.faces.validator.Validator;
+import javax.faces.view.facelets.ComponentHandler;
+import javax.faces.view.facelets.FaceletContext;
+import javax.faces.view.facelets.TagConfig;
+import javax.faces.view.facelets.TagHandler;
+import org.omnifaces.util.Components;
+import org.omnifaces.util.Events;
+import org.omnifaces.util.Faces;
+
+
+/**
+ * A tag handler to skip validation.
+ * 
+ * @author Michele Mariotti
+ */
+public class SkipValidators extends TagHandler
+{
+    public static final String SKIP_VALIDATORS = "org.omnifaces.SKIP_VALIDATORS";
+
+    public SkipValidators(TagConfig config)
+    {
+        super(config);
+    }
+
+    @Override
+    public void apply(final FaceletContext context, final UIComponent parent) throws IOException
+    {
+        if(ComponentHandler.isNew(parent))
+        {
+            parent.subscribeToEvent(PostAddToViewEvent.class, new PostAddToViewEventListener());
+
+            Events.subscribeToViewEvent(PreValidateEvent.class, new PreValidateEventListener());
+            Events.subscribeToViewEvent(PostValidateEvent.class, new PostValidateEventListener());
+        }
+    }
+
+    /**
+     * Check if the given component has been invoked during the current request and if so, set a flag to skip validators.
+     */
+    public static class PostAddToViewEventListener implements ComponentSystemEventListener
+    {
+        @Override
+        public void processEvent(ComponentSystemEvent event) throws AbortProcessingException
+        {
+            UIComponent component = event.getComponent();
+
+            if(Components.hasInvokedSubmit(component))
+            {
+                Faces.setContextAttribute(SKIP_VALIDATORS, true);
+            }
+        }
+    }
+
+    /**
+     * Remove validators and save them to be restored later.
+     */
+    public static class PreValidateEventListener implements SystemEventListener
+    {
+        @Override
+        public void processEvent(SystemEvent event) throws AbortProcessingException
+        {
+            UIInput input = (UIInput) event.getSource();
+
+            boolean skipValidators = Faces.getContextAttribute(SKIP_VALIDATORS) == Boolean.TRUE;
+
+            if(skipValidators)
+            {
+                Faces.setContextAttribute(input.getClientId() + ".required", input.isRequired());
+                input.setRequired(false);
+
+                Validator[] validators = input.getValidators();
+                if(validators != null)
+                {
+                    Faces.setContextAttribute(input.getClientId() + ".validators", validators);
+                    for(Validator validator : validators)
+                    {
+                        input.removeValidator(validator);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean isListenerForSource(Object source)
+        {
+            return source instanceof UIInput;
+        }
+    }
+
+    /**
+     * Restore previously saved validators.
+     */
+    public static class PostValidateEventListener implements SystemEventListener
+    {
+        @Override
+        public void processEvent(SystemEvent event) throws AbortProcessingException
+        {
+            UIInput input = (UIInput) event.getSource();
+
+            boolean skipValidators = Faces.getContextAttribute(SKIP_VALIDATORS) == Boolean.TRUE;
+
+            if(skipValidators)
+            {
+                boolean required = Faces.getContextAttribute(input.getClientId() + ".required") == Boolean.TRUE;
+                input.setRequired(required);
+
+                Validator[] validators = Faces.getContextAttribute(input.getClientId() + ".validators");
+                if(validators != null)
+                {
+                    for(Validator validator : validators)
+                    {
+                        input.addValidator(validator);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean isListenerForSource(Object source)
+        {
+            return source instanceof UIInput;
+        }
+    }
+}

--- a/src/main/resources/META-INF/omnifaces-ui.taglib.xml
+++ b/src/main/resources/META-INF/omnifaces-ui.taglib.xml
@@ -3602,6 +3602,21 @@ public enum Baz {
 	<tag>
 		<description>
 			<![CDATA[
+				The <code>&lt;o:skipValidators&gt;</code> allows the developer to skip validators when
+				executing a submit. This taghandler must be placed inside the component that invokes the submit, may be an 
+                <code>UICommand</code> (both ajaxified or not) as well as any ajax enabled component.
+				<p>
+				Validation will happen, but no validator will be executed since they will be temporary detached from processed components. 
+                Conversion errors could still occur. Note that the model values will be updated for all processed components.
+			]]>
+		</description>
+		<tag-name>skipValidators</tag-name>
+		<handler-class>org.omnifaces.taghandler.SkipValidators</handler-class>
+	</tag>
+
+	<tag>
+		<description>
+			<![CDATA[
 				The <code>&lt;o:enableRestorableView&gt;</code> instructs the view handler to recreate the entire view whenever the
 				view has been expired, i.e. whenever <code>#restoreView(FacesContext, String)</code> returns <code>null</code> and the
 				current request is a postback. This effectively prevents <code>ViewExpiredException</code> on the view. This tag needs to


### PR DESCRIPTION
Hi guys,
`o:ignoreValidationFailed` was not sufficient in some situation (I was working with editable primefaces trees), so I found a way to "deceive" UIInput validation implementation.
I hope it's useful.
Thank you for your work!