### PR TITLE
Performance issue with Converter,

### DIFF
--- a/src/main/java/org/omnifaces/cdi/converter/ConverterManager.java
+++ b/src/main/java/org/omnifaces/cdi/converter/ConverterManager.java
@@ -81,6 +81,7 @@ import org.omnifaces.application.OmniApplicationFactory;
  *
  * @author Radu Creanga {@literal <rdcrng@gmail.com>}
  * @author Bauke Scholtz
+ * @author Robert Alexandersson
  * @see OmniApplication
  * @see OmniApplicationFactory
  * @since 1.6
@@ -92,8 +93,8 @@ public class ConverterManager {
 
 	@Inject
 	private BeanManager manager;
-	private Map<String, Bean<Converter>> convertersById = new HashMap<>();
-	private Map<Class<?>, Bean<Converter>> convertersByForClass = new HashMap<>();
+	private Map<String, Converter> converterStringMap = new HashMap<>();
+	private Map<Class, Converter> converterClassMap = new HashMap<>();
 
 	// Actions --------------------------------------------------------------------------------------------------------
 
@@ -105,21 +106,18 @@ public class ConverterManager {
 	 * @return the converter instance associated with the given converter ID,
 	 * or <code>null</code> if there is none.
 	 */
-	@SuppressWarnings("unchecked")
 	public Converter createConverter(Application application, String converterId) {
-		Bean<Converter> bean = convertersById.get(converterId);
-
-		if (bean == null && !convertersById.containsKey(converterId)) {
-			Converter converter = application.createConverter(converterId);
-
+		Converter converter = converterStringMap.get(converterId);
+		if (converter == null) {
+			converter = application.createConverter(converterId);
 			if (converter != null) {
-				bean = (Bean<Converter>) resolve(manager, converter.getClass());
+				converter = prepareBeanAndInjectDependencies(converter);
+				converterStringMap.put(converterId, converter);
+			}else{
+				throw new IllegalAccessError("Converter was not created");
 			}
-
-			convertersById.put(converterId, bean);
 		}
-
-		return (bean != null) ? getReference(manager, bean) : null;
+		return converter;
 	}
 
 	/**
@@ -130,21 +128,34 @@ public class ConverterManager {
 	 * @return the converter instance associated with the given converter for-class,
 	 * or <code>null</code> if there is none.
 	 */
-	@SuppressWarnings("unchecked")
 	public Converter createConverter(Application application, Class<?> converterForClass) {
-		Bean<Converter> bean = convertersByForClass.get(converterForClass);
-
-		if (bean == null && !convertersByForClass.containsKey(converterForClass)) {
-			Converter converter = application.createConverter(converterForClass);
-
+		Converter converter = converterClassMap.get(converterForClass);
+		if (converter == null) {
+			converter = application.createConverter(converterForClass);
 			if (converter != null) {
-				bean = (Bean<Converter>) resolve(manager, converter.getClass());
+				converter = prepareBeanAndInjectDependencies(converter);
+				converterClassMap.put(converterForClass, converter);
+			}else{
+				throw new IllegalAccessError("Converter was not created");
 			}
-
-			convertersByForClass.put(converterForClass, bean);
 		}
+		return converter;
+	}
 
-		return (bean != null) ? getReference(manager, bean) : null;
+	@SuppressWarnings("unchecked")
+	private Converter prepareBeanAndInjectDependencies(Converter converter) {
+		// Prepares for injection
+		Bean<Converter> bean = (Bean<Converter>) resolve(manager, converter.getClass());
+		// Performs injection
+		if(bean != null) {
+			converter = getReference(manager, bean);
+		} else {
+			// Throw error if the class has an annotation and failed to create a managed bean
+			if (converter.getClass().isAnnotationPresent(FacesConverter.class)) {
+				throw new IllegalAccessError("Converter is not registered as a CDI managed bean "+converter.getClass());
+			}
+		}
+		return converter;
 	}
 
 }

--- a/src/main/java/org/omnifaces/cdi/converter/ConverterManager.java
+++ b/src/main/java/org/omnifaces/cdi/converter/ConverterManager.java
@@ -135,9 +135,8 @@ public class ConverterManager {
 			if (converter != null) {
 				converter = prepareBeanAndInjectDependencies(converter);
 				converterClassMap.put(converterForClass, converter);
-			}else{
-				throw new IllegalAccessError("Converter was not created");
 			}
+			// If converter is null it means a class without converter interface was sent in, throw no exception
 		}
 		return converter;
 	}

--- a/src/main/java/org/omnifaces/util/concurrentlinkedhashmap/ConcurrentLinkedHashMap.java
+++ b/src/main/java/org/omnifaces/util/concurrentlinkedhashmap/ConcurrentLinkedHashMap.java
@@ -44,6 +44,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -180,6 +182,8 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
 	// From Hacker's Delight, Chapter 3, Harry S. Warren Jr.
 	return 1 << (Integer.SIZE - Integer.numberOfLeadingZeros(x - 1));
   }
+
+  static final Executor EXECUTOR = Executors.newFixedThreadPool(10);
 
   /** The draining status of the buffers. */
   enum DrainStatus {
@@ -743,7 +747,14 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
 	if (node == null) {
 	  return null;
 	}
-	afterCompletion(new ReadTask(node));
+      EXECUTOR.execute(
+              new Runnable() {
+                  @Override
+                  public void run() {
+                      afterCompletion(new ReadTask(node));
+                  }
+              }
+      );
 	return node.getValue();
   }
 


### PR DESCRIPTION
New version stores the converter as a singleton only once for the ConverterManager
Makes the solution work for pages with 1000+ converters (tested with 3000 converters)

In my application a page has 3000 converters and with old solution It took 300ms or more to just create the Converters. With this solution it takes 1ms or less as each converter is treated as a singleton and is as fast as the access to the local Map once created and injected.