### PR TITLE
fix o:moveComponent "WARNING Unable to save dynamic action"

### DIFF
--- a/src/main/java/org/omnifaces/component/util/MoveComponent.java
+++ b/src/main/java/org/omnifaces/component/util/MoveComponent.java
@@ -125,6 +125,10 @@ public class MoveComponent extends UtilFamily implements SystemEventListener, Cl
 		if (event instanceof PreRenderViewEvent || (event instanceof PostAddToViewEvent && getDestination() == BEHAVIOR)) {
 			doProcess();
 		}
+		
+		// this is invoked on PostAddToView while postback, effectively removing restored components
+		// and on PreRenderView with no effect, since components have been moved already
+		getChildren().clear();
 	}
 
 	@Override


### PR DESCRIPTION
Hello guys,

I'm experimenting with `o:moveComponent` and nested forms:

	<h:form id="form">
		<p:inputText id="outerText" value="#{viewScope.text}" />

        <p:commandButton id="openButton" process="@form" update="@widgetVar(testDialog)"
            oncomplete="PF('testDialog').show()" value="open" />

        <o:moveComponent id="move" for=":#{facesContext.viewRoot.clientId}" destination="ADD_LAST">
            <h:form id="innerForm">
                <p:dialog id="dialog" widgetVar="testDialog" header="test dialog">
                    <p:inputText id="innerText" value="#{viewScope.text}" />

                    <f:facet name="footer">
                        <p:commandButton id="confirmButton" process="@form" update=":form"
                            oncomplete="if(!args.validationFailed) PF('testDialog').hide()" value="submit" />
                    </f:facet>
                </p:dialog>
            </h:form>
        </o:moveComponent>
	</h:form>

I'm using `o:moveComponent` to "extract" the inner form and place it under `h:body`/`viewRoot`, rather "inserting" it elsewhere.

This is working fine, but produces some warning:

	WARNING Unable to save dynamic action with clientId 'form:innerForm:dialog' because the UIComponent cannot be found
	WARNING Unable to save dynamic action with clientId 'form:innerForm:innerText' because the UIComponent cannot be found
	WARNING Unable to save dynamic action with clientId 'form:innerForm:confirmButton' because the UIComponent cannot be found

on subsequent `RESTORE_VIEW` for postback.

However I found it's possible to eliminate these warnings removing restored children on `PostAddToView`.

I haven't tested if this can have side effects while moving facets or behaviors, but it's working fine with just components.

Tested with Wildfly 10.0.0.Final (jsf-impl-2.2.12-jbossorg-2)