### PR TITLE
Fail validation if @Param required attribute is not satisfied

### DIFF
--- a/src/main/java/org/omnifaces/cdi/param/RequestParameterProducer.java
+++ b/src/main/java/org/omnifaces/cdi/param/RequestParameterProducer.java
@@ -124,6 +124,7 @@ public class RequestParameterProducer {
 
 			if (requestParameter.required() && isEmpty(convertedValue)) {
 				addRequiredMessage(context, component, label, submittedValue, getRequiredMessage(requestParameter));
+				valid = false;
 			}
 
 			// Validate the converted value
@@ -132,8 +133,9 @@ public class RequestParameterProducer {
 			if (shouldDoBeanValidation(requestParameter)) {
 
 				Set<ConstraintViolation<?>> violations = doBeanValidation(convertedValue, injectionPoint);
-
-				valid = violations.isEmpty();
+				if (!violations.isEmpty()) {
+					valid = false;
+				}
 
 				for (ConstraintViolation<?> violation : violations) {
 					context.addMessage(component.getClientId(context), createError(violation.getMessage(), label));


### PR DESCRIPTION
Current if the a request parameter is injected with `@Param(required = true)` and the parameter is null or empty, a validation message is added but the validation is not considered failed.
Therefore `Faces.isValidationFailed()` will return `false`.

The Bean validation works though. So adding `@NotNull` on the attribute will work as expected.

Anyway it might still be desirable to fail the validation in the case with `@Param(required = true)`  and no Bean validation defined.