### PR TITLE
validateBean showMessageFor="@violating" feature

### DIFF
--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -526,14 +526,14 @@ public class ValidateBean extends TagHandler {
 				addGlobalError(violation.getMessage(), labels);
 			}
 		}
-		else if (showMessageFor.equals("@violating")) {
+		else if ("@violating".equals(showMessageFor)) {
 			Set<ConstraintViolation<?>> unmatched = new LinkedHashSet<>(violations);
 			for (ConstraintViolation<?> violation : violations) {
 				final String message = violation.getMessage();
 				final boolean[] matched = new boolean[1];
 				forEachInputWithMatchingBase(context, form, violation.getRootBean(), violation.getPropertyPath().toString(), new Callback.WithArgument<UIInput>() { @Override public void invoke(UIInput input) {
 						input.setValid(false);
-						addError(input.getClientId(), message, Components.getLabel(input));
+						addError(input.getClientId(), message, getLabel(input));
 						matched[0] = true;
 					}
 				});

--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -353,7 +353,7 @@ public class ValidateBean extends TagHandler {
 		ValidateBeanCallback collectBeanProperties = new ValidateBeanCallback() { @Override public void run() {
 			FacesContext context = FacesContext.getCurrentInstance();
 
-			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<EditableValueHolder>() { @Override public void invoke(EditableValueHolder v) {
+			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<UIInput>() { @Override public void invoke(UIInput v) {
 				addCollectingValidator(v, clientIds, properties);
 			}});
 		}};
@@ -361,7 +361,7 @@ public class ValidateBean extends TagHandler {
 		ValidateBeanCallback checkConstraints = new ValidateBeanCallback() { @Override public void run() {
 			FacesContext context = FacesContext.getCurrentInstance();
 
-			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<EditableValueHolder>() { @Override public void invoke(EditableValueHolder v) {
+			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<UIInput>() { @Override public void invoke(UIInput v) {
 				removeCollectingValidator(v);
 			}});
 
@@ -389,7 +389,7 @@ public class ValidateBean extends TagHandler {
 
 	// Helpers --------------------------------------------------------------------------------------------------------
 
-	private static void forEachInputWithMatchingBase(final FacesContext context, UIComponent form, final Object base, final Callback.WithArgument<EditableValueHolder> callback) {
+	private static void forEachInputWithMatchingBase(final FacesContext context, UIComponent form, final Object base, final String property, final Callback.WithArgument<UIInput> callback) {
 		forEachComponent(context)
 			.fromRoot(form)
 			.ofTypes(EditableValueHolder.class)
@@ -401,10 +401,15 @@ public class ValidateBean extends TagHandler {
 					ValueReference valueReference = getValueReference(context.getELContext(), valueExpression);
 
 					if (valueReference.getBase().equals(base)) {
-						callback.invoke((EditableValueHolder) component);
+						if (property == null || property.equals(valueReference.getProperty()))
+							callback.invoke((UIInput) component);
 					}
 				}
 			}});
+	}
+
+	private static void forEachInputWithMatchingBase(final FacesContext context, UIComponent form, final Object base, final Callback.WithArgument<UIInput> callback) {
+		forEachInputWithMatchingBase(context, form, base, null, callback);
 	}
 
 	private static void addCollectingValidator(EditableValueHolder valueHolder, Set<String> clientIds, Map<String, Object> properties) {

--- a/src/main/resources/META-INF/omnifaces-ui.taglib.xml
+++ b/src/main/resources/META-INF/omnifaces-ui.taglib.xml
@@ -4389,8 +4389,9 @@ public enum Baz {
 				<![CDATA[
 					The identifier for which this validator should show the message. Defaults to "@form" which is the
 					parent <code>UIForm</code>. Other available values are "@all" which will show the message for all
-					invalidated components and "@global" which will show a global message. Any other space separated
-					value will be treated as client ID of UI input component.
+					invalidated components, "@global" which will show a global message, and "@violating" which will
+					match components by ConstraintViolation Property Path. Any other space separated value will be
+					treated as client ID of UI input component.
 				]]>
 			</description>
 			<name>showMessageFor</name>


### PR DESCRIPTION
Hello Bauke, this patch adds a feature to o:validateBean: showMessageFor="@violating".

I've been rather fond of the JSR-303 Bean Validation API, which works great at the JPA level, but it seems that JSF rarely integrates with it, particularly cross-field validation.

I've scanned through the source code of omnifaces, deltaspike, and primefaces projects and discovered that none of them peek into the ConstraintViolation rootNode + propertyPath fields.

This feature matches JSR 303 propertyPath to the UIComponents EL ValueReference.

I'd be happy to rework this patch if you have any suggestions (or hack on showcase example or whatever).