### PR TITLE
Add showViolatingUnmatchedFor attribute to validateBean tag handler

### DIFF
--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -63,6 +63,9 @@ import javax.faces.component.UICommand;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIForm;
 import javax.faces.component.UIInput;
+import javax.faces.component.visit.VisitCallback;
+import javax.faces.component.visit.VisitContext;
+import javax.faces.component.visit.VisitResult;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PostValidateEvent;
 import javax.faces.event.PreValidateEvent;
@@ -312,6 +315,15 @@ public class ValidateBean extends TagHandler {
 		}
 
 		Object bean = (value != null) ? value.getValue(getELContext()) : null;
+
+		if (value != null && bean == null) {
+			final Object[] beans = new Object[1];
+			forEachComponent().fromRoot(form).havingIds(component.getClientId()).invoke(new VisitCallback() { @Override public VisitResult visit(VisitContext context, UIComponent target) {
+				beans[0] = value.getValue(getELContext());
+				return VisitResult.COMPLETE;
+			}});
+			bean = beans[0];
+		}
 
 		if (bean == null) {
 			validateForm(groups, disabled);

--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -268,6 +268,7 @@ public class ValidateBean extends TagHandler {
 	private String groups;
 	private String copier;
 	private String showMessageFor;
+	private String showViolatingUnmatchedFor;
 
 	// Constructors ---------------------------------------------------------------------------------------------------
 
@@ -306,6 +307,7 @@ public class ValidateBean extends TagHandler {
 		groups = getString(context, getAttribute("validationGroups"));
 		copier = getString(context, getAttribute("copier"));
 		showMessageFor = coalesce(getString(context, getAttribute("showMessageFor")), DEFAULT_SHOWMESSAGEFOR);
+		showViolatingUnmatchedFor = coalesce(getString(context, getAttribute("showViolatingUnmatchedFor")), DEFAULT_SHOWMESSAGEFOR);
 
 		// We can't use getCurrentForm() or hasInvokedSubmit() before the component is added to view, because the client ID isn't available.
 		// Hence, we subscribe this check to after phase of restore view.
@@ -440,16 +442,16 @@ public class ValidateBean extends TagHandler {
 
 		if (!violations.isEmpty()) {
 			context.validationFailed();
-			String showMessagesFor = showMessageFor;
 
 			if ("@violating".equals(showMessageFor)) {
 				violations = invalidateInputsByPropertyPathAndShowMessages(context, form, actualBean, violations, clientIds);
-				showMessagesFor = DEFAULT_SHOWMESSAGEFOR;
+				if (!violations.isEmpty() && !"@none".equals(showViolatingUnmatchedFor)) {
+					showMessages(context, form, violations, clientIds, null, showViolatingUnmatchedFor);
+				}
 			}
-
-			if (!violations.isEmpty()) {
+			else {
 				String labels = invalidateInputsByClientIdsAndCollectLabels(context, form, clientIds);
-				showMessages(context, form, violations, clientIds, labels, showMessagesFor);
+				showMessages(context, form, violations, clientIds, labels, showMessageFor);
 			}
 
 			if (renderResponseOnFail) {

--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -365,7 +365,7 @@ public class ValidateBean extends TagHandler {
 		ValidateBeanCallback collectBeanProperties = new ValidateBeanCallback() { @Override public void run() {
 			FacesContext context = FacesContext.getCurrentInstance();
 
-			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<EditableValueHolder>() { @Override public void invoke(EditableValueHolder v) {
+			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<UIInput>() { @Override public void invoke(UIInput v) {
 				addCollectingValidator(v, clientIds, properties);
 			}});
 		}};
@@ -373,7 +373,7 @@ public class ValidateBean extends TagHandler {
 		ValidateBeanCallback checkConstraints = new ValidateBeanCallback() { @Override public void run() {
 			FacesContext context = FacesContext.getCurrentInstance();
 
-			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<EditableValueHolder>() { @Override public void invoke(EditableValueHolder v) {
+			forEachInputWithMatchingBase(context, form, bean, new Callback.WithArgument<UIInput>() { @Override public void invoke(UIInput v) {
 				removeCollectingValidator(v);
 			}});
 
@@ -401,7 +401,7 @@ public class ValidateBean extends TagHandler {
 
 	// Helpers --------------------------------------------------------------------------------------------------------
 
-	private static void forEachInputWithMatchingBase(final FacesContext context, UIComponent form, final Object base, final Callback.WithArgument<EditableValueHolder> callback) {
+	private static void forEachInputWithMatchingBase(final FacesContext context, UIComponent form, final Object base, final String property, final Callback.WithArgument<UIInput> callback) {
 		forEachComponent(context)
 			.fromRoot(form)
 			.ofTypes(EditableValueHolder.class)
@@ -413,10 +413,15 @@ public class ValidateBean extends TagHandler {
 					ValueReference valueReference = getValueReference(context.getELContext(), valueExpression);
 
 					if (valueReference.getBase().equals(base)) {
-						callback.invoke((EditableValueHolder) component);
+						if (property == null || property.equals(valueReference.getProperty()))
+							callback.invoke((UIInput) component);
 					}
 				}
 			}});
+	}
+
+	private static void forEachInputWithMatchingBase(final FacesContext context, UIComponent form, final Object base, final Callback.WithArgument<UIInput> callback) {
+		forEachInputWithMatchingBase(context, form, base, null, callback);
 	}
 
 	private static void addCollectingValidator(EditableValueHolder valueHolder, Set<String> clientIds, Map<String, Object> properties) {

--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -204,6 +205,24 @@ import org.omnifaces.util.copier.SerializationCopier;
  *     &lt;h:message for="bar" /&gt;
  *     ...
  *     &lt;o:validateBean ... showMessageFor="foo bar" /&gt;
+ * &lt;/h:form&gt;
+ * </pre>
+ * <p>
+ * The faces message can also be shown for components which match {@link ConstraintViolation#getPropertyPath() Property
+ * Path of the ConstraintViolation} using <code>showMessageFor="@violating"</code>, and when no matching component can
+ * be found, the message will fallback to being added with client ID of the parent {@link UIForm}.
+ * <pre>
+ * &lt;h:form id="formId"&gt;
+ *     ...
+ *     &lt;!-- Unmatched messages shown here: --&gt;
+ *     &lt;h:message for="formId" /&gt;
+ *     ...
+ *     &lt;h:inputText id="foo" value="#{bean.product.item}" /&gt;
+ *
+ *     &lt;!-- Messages where ConstraintViolation PropertyPath is "item" are shown here: --&gt;
+ *     &lt;h:message for="foo" /&gt;
+ *     ...
+ *     &lt;o:validateBean ... value="#{bean.product}" showMessageFor="@violating" /&gt;
  * &lt;/h:form&gt;
  * </pre>
  * <p>
@@ -480,10 +499,12 @@ public class ValidateBean extends TagHandler {
 			final StringBuilder labels = new StringBuilder();
 
 			if (!clientIds.isEmpty()) {
+				final boolean invalidate = !showMessageFor.equals("@violating");
 				forEachComponent(context).fromRoot(form).havingIds(clientIds).invoke(new Callback.WithArgument<UIInput>() {
 					@Override
 					public void invoke(UIInput input) {
-						input.setValid(false);
+						if (invalidate)
+							input.setValid(false);
 
 						if (labels.length() > 0) {
 							labels.append(", ");
@@ -516,6 +537,23 @@ public class ValidateBean extends TagHandler {
 			for (ConstraintViolation<?> violation : violations) {
 				addGlobalError(violation.getMessage(), labels);
 			}
+		}
+		else if (showMessageFor.equals("@violating")) {
+			Set<ConstraintViolation<?>> unmatched = new LinkedHashSet<>(violations);
+			for (ConstraintViolation<?> violation : violations) {
+				final String message = violation.getMessage();
+				final boolean[] matched = new boolean[1];
+				forEachInputWithMatchingBase(context, form, violation.getRootBean(), violation.getPropertyPath().toString(), new Callback.WithArgument<UIInput>() { @Override public void invoke(UIInput input) {
+						input.setValid(false);
+						addError(input.getClientId(), message, Components.getLabel(input));
+						matched[0] = true;
+					}
+				});
+				if (matched[0])
+					unmatched.remove(violation);
+			}
+			if (!unmatched.isEmpty() && !showMessageFor.equals(DEFAULT_SHOWMESSAGEFOR))
+				showMessages(context, form, unmatched, clientIds, labels, DEFAULT_SHOWMESSAGEFOR);
 		}
 		else {
 			for (String clientId : showMessageFor.split("\\s+")) {

--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -538,14 +538,14 @@ public class ValidateBean extends TagHandler {
 				addGlobalError(violation.getMessage(), labels);
 			}
 		}
-		else if (showMessageFor.equals("@violating")) {
+		else if ("@violating".equals(showMessageFor)) {
 			Set<ConstraintViolation<?>> unmatched = new LinkedHashSet<>(violations);
 			for (ConstraintViolation<?> violation : violations) {
 				final String message = violation.getMessage();
 				final boolean[] matched = new boolean[1];
 				forEachInputWithMatchingBase(context, form, violation.getRootBean(), violation.getPropertyPath().toString(), new Callback.WithArgument<UIInput>() { @Override public void invoke(UIInput input) {
 						input.setValid(false);
-						addError(input.getClientId(), message, Components.getLabel(input));
+						addError(input.getClientId(), message, getLabel(input));
 						matched[0] = true;
 					}
 				});

--- a/src/main/resources/META-INF/omnifaces-ui.taglib.xml
+++ b/src/main/resources/META-INF/omnifaces-ui.taglib.xml
@@ -4398,6 +4398,20 @@ public enum Baz {
 			<required>false</required>
 			<type>java.lang.String</type>
 		</attribute>
+		<attribute>
+			<description>
+				<![CDATA[
+					The identifier for which this validator should show any messages left over when <code>showMessageFor</code>
+					is set to "@violating" and there are ConstraintViolations which could not be matched to any components by
+					Property Path. Defaults to "@form" which which is the parent <code>UIForm</code>. Other available values
+					are "@all" which will show the message for all invalidated components, "@global" which will show a global
+					message, and "@none" ignore the ConstraintViolation.
+				]]>
+			</description>
+			<name>showViolatingUnmatchedFor</name>
+			<required>false</required>
+			<type>java.lang.String</type>
+		</attribute>
 	</tag>
 
 	<tag>

--- a/src/main/resources/META-INF/omnifaces-ui.taglib.xml
+++ b/src/main/resources/META-INF/omnifaces-ui.taglib.xml
@@ -4389,8 +4389,9 @@ public enum Baz {
 				<![CDATA[
 					The identifier for which this validator should show the message. Defaults to "@form" which is the
 					parent <code>UIForm</code>. Other available values are "@all" which will show the message for all
-					invalidated components and "@global" which will show a global message. Any other space separated
-					value will be treated as client ID of UI input component.
+					invalidated components, "@global" which will show a global message, and "@violating" which will
+					match components by ConstraintViolation Property Path. Any other space separated value will be
+					treated as client ID of UI input component.
 				]]>
 			</description>
 			<name>showMessageFor</name>


### PR DESCRIPTION
Fix for issue #352:  Add showViolatingUnmatchedFor attribute to validateBean tag handler so that default fallback of `"@form"` can be overriden by the page author, supports the same idenifiers as showMessageFor, and additonally supports `"@none"` which discards the unmatched ConstraintViolations.  Furthermore when showMessageFor is `"@violating"`, avoid calling setValid(false) on all UIInputs.
