### PR TITLE
Add support for components that can generate links to MultiViews pages.

### DIFF
--- a/src/main/java/org/omnifaces/component/output/Button.java
+++ b/src/main/java/org/omnifaces/component/output/Button.java
@@ -1,0 +1,924 @@
+/*
+ * Copyright 2017 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.component.output;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import javax.el.ValueExpression;
+//import javax.faces.FacesException;
+import javax.faces.application.ConfigurableNavigationHandler;
+import javax.faces.application.FacesMessage;
+import javax.faces.application.NavigationCase;
+import javax.faces.application.ProjectStage;
+import javax.faces.application.ViewHandler;
+import javax.faces.component.FacesComponent;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UIParameter;
+import javax.faces.component.html.HtmlOutcomeTargetButton;
+import javax.faces.context.FacesContext;
+import javax.faces.context.ResponseWriter;
+import javax.faces.event.ActionListener;
+import javax.faces.event.PreRenderComponentEvent;
+import javax.faces.flow.FlowHandler;
+import javax.faces.lifecycle.ClientWindow;
+import javax.servlet.ServletContext;
+
+import static org.omnifaces.util.Renderers.writeIdAttributeIfNecessary;
+import static org.omnifaces.util.Servlets.getApplicationAttribute;
+import static org.omnifaces.util.Utils.encodeURI;
+import static org.omnifaces.util.Utils.encodeURL;
+
+/**
+ * The <code>&lt;o:button&gt;</code> is a component that extends the standard <code>&lt;h:button&gt;</code> component to support 
+ * <code>MultiViews</code> feature of {@link org.omnifaces.facesviews.FacesViews} by rendering the supplied <code>&lt;o:pathParam&gt;</code>
+ * parameters as path parameters and not as query parameters as otherwise will be produced by standard <code>&lt;o:param&gt;</code> and 
+ * <code>&lt;f:param&gt;</code>, or if <code>&lt;o:pathParam&gt;</code> tags are nested in a standard <code>&lt;h:button&gt;</code>.
+ * <p>
+ * To achieve this goal <code>&lt;o:pathParam&gt;</code> tags must be specified as children of <code>&lt;o:button&gt;</code>. See {@link PathParam}
+ * for an overview of configuration of path parameters. Any <code>&lt;o:pathParam&gt;</code> tag will be rendered as a part of the URL path of 
+ * this component, like <i>/path-parameter-evaluated-value</i>, if the following conditions are met:
+ * <ol>
+ * <li>
+ * <code>outcome</code> attribute of the current <code>&lt;o:button&gt;</code> component specifies a valid MultiView page, 
+ * see {@link org.omnifaces.facesviews.FacesViews} for a proper way of configuring <code>MultiViews</code> feature.
+ * </li>
+ * <li>
+ * <code>basic</code> attribute of the current component must evaluate to false (or left as default).
+ * </li>
+ * <li>
+ * <code>basic</code> attribute of <code>&lt;o:pathParam&gt;</code> tag must evaluate to false (or left as default).
+ * </li>
+ * </ol>
+ * <p>
+ * The ordering of path parameters will be defined according to the <code>index</code> attribute of <code>&lt;o:pathParam&gt;</code> tags. 
+ * In case of collisions the tags with equal indices, either specified and unspecified, will be rendered in the order they were defined. 
+ * The location of paths with unspecified indices will be derived from <code>location</code> attribute of this component, see description below. 
+ * Location and indices only specify relative context of rendering, or before-after relation. Negative indices are also supported.
+ * <p>
+ * This component also accepts standard parameters, <code>&lt;o:param&gt;</code> and <code>&lt;f:param&gt;</code>, and will render
+ * them as query parameters, as it has always traditionally been done by {@link UIOutcomeTarget} components like <code>&lt;h:link&gt;</code> and 
+ * <code>&lt;h:button&gt;</code>. <code>&lt;o:pathParam&gt;</code> tags can also be rendered as query parameters if their <code>basic</code>
+ * attributes evaluate to true. It can be helpful if an application has to decide upon way of rendering at runtime, by checking 
+ * <code>#{someCondition}</code>.
+ * <p>
+ * The component specifies three additional non-required attributes to control and fine-tune the generated path from path parameters:
+ * <ul>
+ * <li>
+ * <code>location</code>, non-required attribute that defines the location where <code>&lt;o:pathParam&gt;</code> tags with non-specified 
+ * <code>index</code> attributes relative to the ones with the specified <code>index</code> attribute will be rendered: after all path 
+ * parameters for attribute value "end", before all path parameters for attribute value "beginning" or at a specified location for attribute 
+ * integer value, i.e. for components where <code>Integer.valueOf(getLocation())</code> doesn't throw <code>NumberFormatException</code>. 
+ * Default value of this attribute is "end". All other values will be treated as "end" as well.
+ * </li>
+ * <li>
+ * <code>force</code>, non-required attribute that defines behaviour when <code>outcome</code> attribute doesn't specify a valid MultiView page:
+ * if the attribute value is true then if any <code>&lt;o:pathParam&gt;</code> with <code>basic</code> attribute evaluating to false are present 
+ * the component will be rendered as disabled and generate a {@link FacesMessage} that the outcome is not a valid MultiView page, if the 
+ * attribute value is false, any <code>&lt;o:pathParam&gt;</code> tag will be treated as simple <code>&lt;o:param&gt;</code> thus producing 
+ * query parameters for all parameters with a specified non-empty name. Default value is true.
+ * </li>
+ * <li>
+ * <code>basic</code>, non-required attribute that is used to turn off dealing with <code>&lt;o:pathParam&gt;</code> tags as path parameters.
+ * If this property evaluates to true, all present <code>&lt;o:pathParam&gt;</code> tags will be treated as <code>&lt;o:param&gt;</code> tags,
+ * thus overriding all preset behaviour of the component and its children. If this property evaluates to false, the rendering will proceed
+ * in a standard fashion, described above. This attribute is helpful when an application needs to turn off defined behaviour basing on
+ * some condition. Default value is false.
+ * </li>
+ * </ul>
+ * <p>
+ * There are four additional properties to the ones defined in <code>&lt;h:button&gt;</code> to account for extra features: 
+ * <ul>
+ * <li>
+ * <code>disabled</code>, non-required attribute that serves as a flag to disable the button. Default value is false.
+ * </li>
+ * <li>
+ * <code>target</code>, non-required attribute that defines the name of a frame where the resource of this component will be displayed. Default value is "_self".
+ * </li>
+ * <li>
+ * <code>fragment</code>, non-required attribute that attaches hash-separated fragment at the end of the URL, if present and not empty.
+ * </li>
+ * <li>
+ * <code>escape</code>, non-required attribute that defines whether or not to escape the value of this component. Default value is true.
+ * Beware of potential XSS attack holes when redisplaying user-controlled input with <code>escape="false"</code>.
+ * </li>
+ * </ul>
+ * <p>
+ * This component is useful when application must provide links to the MultiView-configured pages with parameters rendered as part of the 
+ * path and not a part of the query string, as it is traditionally done. The sending page defines a <code>&lt;o:button&gt;</code> with 
+ * <code>&lt;o:pathParam&gt;</code>s, thus generating URL with path parameters, and the receiving page consumes these path parameters in 
+ * CDI beans by means of {@link org.omnifaces.cdi.Param} with a specified <code>pathIndex</code> property.
+ * <p>
+ * There are some options, described above, for tuning the generated URL of this component in various circumstances. This component 
+ * can also be used to generate standard buttons for non-MultiView pages as well as buttons for MultiView pages with standard appearance.
+ * <p>
+ * The component provides a set of predefined CSS classes to support defining styles for all used components of this type in ones place. Additionally,
+ * user-defined CSS classes can be added via the traditional <code>styleClass</code> attribute for the generated <code>button</code> HTML element and 
+ * via the <code>image</code> attribute for the nested <code>span</code> HTML element, where the image has to be referenced via the CSS 
+ * <code>background-image</code> property. In case the <code>image</code> attribute is absent, no image span will be rendered. Also note that it 
+ * is the application responsibility to create right CSS classes for proper appearance of the button. Text of the button will be rendered in the 
+ * <code>span</code> HTML element, next to the image element, if there is one. If no <code>image</code> attribute is specified, the text 
+ * element will be rendered in any case, either with the supplied component value, or with the default text, if no <code>value</code> attribute was 
+ * declared. The value of the component will be rendered as the button text. No declared children will be rendered to HTML output.
+ * These classes are:
+ * <ul>
+ * <li>"of-button" for all generated active <code>button</code> HTML elements and "of-button-disabled" for all disabled ones.</li>
+ * <li>"of-button-image" for all generated <code>span</code> HTML elements for referencing the image of the button.</li>
+ * <li>"of-button-text" for all generated <code>span</code> HTML elements for holding the text of the button.</li>
+ * </ul>
+ * <p>
+ * Basic usage examples follow. They assume that {@link org.omnifaces.facesviews.FacesViews} is turned on and <code>MultiViews</code>
+ * configuration is present for paths "/users/*", "/path/*" and "/blog/*":
+ * <pre>
+ * &lt;context-param&gt;
+ *     &lt;param-name&gt;org.omnifaces.FACES_VIEWS_SCAN_PATHS&lt;/param-name&gt;
+ *     &lt;param-value&gt;/*.xhtml, /user/*, /path/*, /blog/*&lt;/param-value&gt;
+ * &lt;/context-param&gt;
+ * </pre>
+ * For additional information on how to configure FacesViews and use the MutiViews feature see {@link org.omnifaces.facesviews.FacesViews}.
+ * <p>
+ * In the following example the component generates a button to a view user detail page by employing implicit <code>@FacesConverter(forClass)</code>
+ * converter.
+ * <pre>
+ * &lt;o:button value="User details" outcome="user"&gt;
+ *     &lt;o:pathParam&gt; value="#{bean.user}" /&gt;
+ * &lt;/o:button&gt;
+ * </pre>
+ * with
+ * <pre>
+ *{@literal @}FacesConverter(forClass = User.class) public class UserConverter implements Converter {
+ *     public Object getAsObject(FacesContext context, UIComponent component, String value) {
+ *         if (value == null) { return null; } return new User(value);
+ *     }
+ *     public String getAsString(FacesContext context, UIComponent component, Object value) {
+ *         if(value == null) { return ""; }
+ *         if(value instanceof User) { User user = (User)value; return user.getUsername(); }
+ *         throw new ConverterException(value + " not a User");
+ *     }
+ * }
+ *{@literal @}Named @RequestScoped public class Bean { private User user; ... }
+ * public class User { private String username; ... }
+ * </pre>
+ * The generated URL referenced by the button could look like <code>/context-path/user/username</code>.
+ * <p>
+ * The following button shows a way of tuning the rendering of path parameters.
+ * <pre>
+ * &lt;o:button value="Button" outcome="path" location="beginning"&gt;
+ *     &lt;o:pathParam&gt; value="first" index="1"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="no-index"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="basic" value="basic" basic="true"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="third" index="3"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="no-index-second" disable="#{someCondition}"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="#{bean.name}" converter="#{bean}" index="2"&lt;/o:pathParam&gt;
+ * &lt;/o:button&gt;
+ * </pre>
+ * The generated URL referenced by the button could look like <code>/context-path/path/no-index/no-index-second/first/bean-name/third?basic=basic</code>.
+ * <p>
+ * Note that if the outcome of the button above pointed at a standard view id, say, <code>index</code> then the construct will
+ * be rendered as a disabled button (impossible to render path parameters at a standard outcome). Still, configuring
+ * &lt;o:button ... force="false" /&gt; will render an active button with all of the parameter rendered as query parameters (for 
+ * parameters with non-empty name). Also note that standard parameters are perfectly legal:
+ * <pre>
+ * &lt;o:button ...&gt;
+ *     &lt;o:pathParam&gt; ...&lt;/o:pathParam&gt;
+ *     &lt;o:param&gt; name="omniparam" value="omniparam"&lt;/o:param&gt;
+ *     &lt;f:param&gt; name="fparam" value="fparam"&lt;/f:param&gt;
+ * &lt;/o:button&gt;
+ * </pre>
+ * Another option to turn off rendering of path parameters altogether is to set a condition for the <code>basic</code> attribute:
+ * <pre>
+ * &lt;o:button value="Button" outcome="path" basic="#{someCondition}"&gt;
+ *     &lt;o:pathParam&gt; name="first" value="first"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="second" value="second"&lt;/o:pathParam&gt;
+ * &lt;/o:button&gt;
+ * </pre>
+ * If <code>#{someCondition}</code> evaluates to false, the URL referenced by the button will be rendered as <code>/context-path/path/first/second</code>,
+ * and if it evaluates to true, the URL referenced by the button will be rendered as <code>/context-path/path?first=first&second=second</code>.
+ * <p>
+ * The significant benefit of using the <code>&lt;o:button&gt;</code> component is its ability to integrate with JSF infrastructure.
+ * The <code>outcome</code> attribute will be internally checked by a {@link NavigationHandler} and {@link ViewHandler} 
+ * and in case of negative result the component will be rendered as disabled and a message will be printed. On the one hand this 
+ * will reduce the number of hand-written errors and on the other hand will incorporate all user-created artifacts, like custom
+ * <code>ViewHandlerWrapper</code> classes with overridden <code>getActionURL(...)</code> methods to reflect and generate valid 
+ * and up-to-date URLs for output components.
+ * <p>
+ * The following component, for example, will be rendered as disabled: <code>&lt;o:button outcome="non-existing-path" .../&gt;</code>.
+ * <p>
+ * The following component will render a button with a prefix, if <code>getActionURL(...)</code> were overridden accordingly to prefix 
+ * all paths of a special subset of views to "/special": <code>&lt;o:button outcome="special-path-for-view-handler" .../&gt;</code>. 
+ * The generated URL could look like <code>/context-path/special/special-path-for-view-handler/...</code>.
+ * <p>
+ * The last example renders URLs basing on available information. For example, we can have a mapping on "/blog" with year, month and 
+ * day specified. The following button could be used to point at a valid blog post overview:
+ * <pre>
+ * &lt;o:button value="Blog" outcome="blog"&gt;
+ *     &lt;o:pathParam&gt; name="year" value="#{userSettings.year}"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="month" value="#{userSettings.month}"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="day" value="#{userSettings.day}"&lt;/o:pathParam&gt;
+ * &lt;/o:button&gt;
+ * </pre>
+ * Of course, some additional logic must be incorporated to check parameters, but the construct above could be used to render buttons 
+ * with referenced URLs of type <code>/context-path/blog/2017</code>, <code>/context-path/blog/2017/october</code> and 
+ * <code>/context-path/blog/2017/october/1</code>, which could be rather fruitful under some circumstances.
+ * 
+ * @author Sergey Kuntsel
+ * @since 3.0
+ * @see Link
+ * @see PathParam
+ */
+@FacesComponent(Button.COMPONENT_TYPE)
+public class Button extends HtmlOutcomeTargetButton {
+    //TODO refactor in favour of a Renderer or create a Utility class to solve common tasks.
+
+    // Constants
+    public static final String COMPONENT_TYPE = "org.omnifaces.component.output.Button";
+    public static final String COMPONENT_FAMILY = "org.omnifaces.component.output";
+
+    // TODO externalize messages and add i18n support
+    private static final String ERROR_NAVIGATION_CASE_NOT_FOUND =
+            "Navigation case couldn't be resolved for the outcome: %s.";
+    private static final String ERROR_MULTIVIEW_NOT_CONFIGURED =
+            "MultiView was not configured for the outcome: %s, but PathParams were defined for it.";
+    private static final String NO_NAVIGATION_CASE = Button.class.getName() + "_NO_NAVIGATION_CASE";
+    private static final String NO_MULTIVIEW_CONFIG = Button.class.getName() + "_NO_MULTIVIEW_CONFIG";
+
+    private static final Logger logger = Logger.getLogger(Button.class.getName());
+    protected static final Map<String, String> ATTRIBUTE_NAMES = getButtonAttributes();
+
+    // Constructor
+    public Button() {
+        setRendererType(null);
+    }
+
+    // Properties
+    private enum PropertyKeys {
+        disabled, // flag for disabling button, default false
+        target, // frame where the outcome will be displayed, default value "_self"
+        fragment, // attach hash-separated fragment at the end of the URL, default null
+        escape, // escape content if explicitly needed, default true
+        location, // location to render path params with unspecified index: at the beginning ("beginning"), at the end ("end") or at the specified index (any Integer value)
+                  //default value "end", any other string and error while converting to Integer equals to "end"
+        force, // if true: when PathParams defined for non-applicable view generate error message, if false: treat PathParams as UIParameters, default true
+        basic; // if true: all PathParams will be treated as UIParameters, thus effectively disabling path parameter behaviour basing on some condition, if false: standard behaviour, default false
+    }
+
+    public Boolean getDisabled() { return (Boolean)getStateHelper().eval(PropertyKeys.disabled, Boolean.FALSE); }
+    public void setDisabled(Boolean disabled) { getStateHelper().put(PropertyKeys.disabled, disabled); }
+    public String getTarget() { return (String)getStateHelper().eval(PropertyKeys.target, "_self"); }
+    public void setTarget(String target) { getStateHelper().put(PropertyKeys.target, target); }
+    public String getFragment() { return (String)getStateHelper().eval(PropertyKeys.fragment); }
+    public void setFragment(String fragment) { getStateHelper().put(PropertyKeys.fragment, fragment); }
+    public Boolean getEscape() { return (Boolean)getStateHelper().eval(PropertyKeys.escape, Boolean.TRUE); }
+    public void setEscape(Boolean escape) { getStateHelper().put(PropertyKeys.escape, escape); }
+    public String getLocation() { return (String)getStateHelper().eval(PropertyKeys.location, "end"); }
+    public void setLocation(String location) { getStateHelper().put(PropertyKeys.location, location); }
+    public Boolean getForce() { return (Boolean)getStateHelper().eval(PropertyKeys.force, Boolean.TRUE); }
+    public void setForce(Boolean escape) { getStateHelper().put(PropertyKeys.force, escape); }
+    public Boolean getBasic() { return (Boolean)getStateHelper().eval(PropertyKeys.basic, Boolean.FALSE); }
+    public void setBasic(Boolean basic) { getStateHelper().put(PropertyKeys.basic, basic); }
+
+    // Superclass overrides
+    @Override
+    public String getFamily() { return COMPONENT_FAMILY; }
+
+    @Override
+    public boolean getRendersChildren() { return true; }
+
+    @Override
+    public void encodeChildren(FacesContext context) throws IOException {
+        // do nothing, so button doesn't accept any children
+    }
+    
+    // Encoding behaviour
+    @Override
+    public void encodeBegin(FacesContext context) throws IOException {
+        if (context == null) { throw new NullPointerException(); }
+        pushComponentToEL(context, null);
+        if (!isRendered()) { return; }
+        context.getApplication().publishEvent(context,PreRenderComponentEvent.class, this);
+
+        boolean disabled = getDisabled();
+        NavigationCase navigationCase = null;
+        boolean navigationCaseNotFound = false;
+        boolean isMultiViewId = false;
+        boolean multiViewIdNotConfigured = false;
+        if (!disabled) {
+            navigationCase = getNavigationCase(context);
+            if(navigationCase == null) {
+                navigationCaseNotFound = true;
+                context.getAttributes().put(NO_NAVIGATION_CASE, true);
+                //throw new FacesException(String.format(ERROR_NAVIGATION_CASE_NOT_FOUND, getOutcome()));
+            } else {
+                isMultiViewId = isMultiViewsEnabled(context, navigationCase);
+                multiViewIdNotConfigured = !isMultiViewId && hasDeclaredActivePathParams();
+                if (multiViewIdNotConfigured) {
+                    context.getAttributes().put(NO_MULTIVIEW_CONFIG, true);
+                    //throw new FacesException(String.format(ERROR_MULTIVIEW_NOT_CONFIGURED, getOutcome()));
+                }
+            }
+        }
+
+        boolean effectivelyDisabled = disabled || navigationCase == null || multiViewIdNotConfigured;
+        
+        ResponseWriter writer = context.getResponseWriter();
+        
+        writer.startElement("button", this);
+        writeIdAttributeIfNecessary(writer, this);
+        writer.writeAttribute("name", getClientId(), "name");
+        writer.writeAttribute("type", "button", null);
+
+        String styleClass = generateStyleClass(effectivelyDisabled);
+        writer.writeAttribute("class", styleClass, "styleClass");
+
+        if (effectivelyDisabled) {
+            writer.writeAttribute("disabled", "disabled", "disabled");
+        }
+
+        String href = (navigationCase != null && !multiViewIdNotConfigured) ? createTargetURL(context, navigationCase, isMultiViewId) : null;
+        String onclick = generateOnclick(href);
+        if(!"".equals(onclick)) {
+            writer.writeAttribute("onclick", onclick, "click");
+        }
+
+        writeButtonAttributes(writer);
+        writePassthroughAttrs(context, writer);
+
+        //image is treated as a CSS class
+        String image = getImage();
+        if (image != null) {
+            image = image.trim();
+            if (!image.equals("")) {
+                writer.startElement("span", null);
+                writer.writeAttribute("class", "of-button-image " + image, null);
+                writer.endElement("span");
+            }
+        }
+
+        if(!(image != null && getValue() == null)) {
+            writer.startElement("span", null);
+            writer.writeAttribute("class", "of-button-text", null);
+            writeValue(writer);
+            writer.endElement("span");
+        }
+
+        if (!context.isProjectStage(ProjectStage.Production)) {
+            if (navigationCaseNotFound) {
+                String message = String.format(ERROR_NAVIGATION_CASE_NOT_FOUND, getOutcome());
+                // FacesMessage was already added via navigation handler
+                if (logger.isLoggable(Level.WARNING)) {
+                    logger.log(Level.WARNING, "{0} Component id: {1}.", new Object[]{message, getId()});
+                }
+            }
+            if (multiViewIdNotConfigured) {
+                String message = String.format(ERROR_MULTIVIEW_NOT_CONFIGURED, getOutcome());
+                addFacesWarnMessage(context, message);
+                if (logger.isLoggable(Level.WARNING)) {
+                    logger.log(Level.WARNING, "{0} Component id: {1}.", new Object[]{message, getId()});
+                }
+            }
+        }
+    }
+
+    @Override
+    public void encodeEnd(FacesContext context) throws IOException {
+        if (context == null) { throw new NullPointerException(); }
+        if (!isRendered()) { popComponentFromEL(context); return; }
+        ResponseWriter writer = context.getResponseWriter();
+        
+        boolean noNavigationCase = context.getAttributes().remove(NO_NAVIGATION_CASE) != null;
+        boolean noMultiViewConfig = context.getAttributes().remove(NO_MULTIVIEW_CONFIG) != null;
+        writer.endElement("button");
+        
+        if (!context.isProjectStage(ProjectStage.Production)) {
+            String message = null;
+            if (noNavigationCase) {
+                message = String.format(ERROR_NAVIGATION_CASE_NOT_FOUND, getOutcome());
+            }
+            if (noMultiViewConfig) {
+                message = String.format(ERROR_MULTIVIEW_NOT_CONFIGURED, getOutcome());
+            }
+            if (message != null) {
+                writer.startElement("span", null);
+                writer.writeAttribute("style", "margin-left: 3px; color: #DC143C", null);
+                writer.write(message);
+                writer.endElement("span");            
+            }
+        }
+        
+        popComponentFromEL(context);
+    }
+
+    // Protected methods
+    /**
+     * Generate onclick for the current button.
+     * 
+     * @param href href value to incorporate in onclick.
+     * @return generated onclick.
+     */
+    protected String generateOnclick(String href) {
+        StringBuilder onclick = new StringBuilder();
+        String onclickAttribute = getOnclick();
+        if (onclickAttribute != null) {
+            onclickAttribute = onclickAttribute.trim();
+            if (!onclickAttribute.equals("")) {
+                onclick.append(onclickAttribute).append(onclickAttribute.endsWith(";") ? " " : "; ");
+            }
+        }
+        if (href != null) {
+            onclick.append("window.open('").append(href.trim()).append("', '")
+                    .append(getTarget()).append("');");
+        }
+        return onclick.toString();
+    }
+    
+    /**
+     * Generate style class for the current button. Any active button has "of-button" class,
+     * any disabled button has "of-button-disabled" class. User-defined classes are 
+     * appended as well.
+     * 
+     * @param disabled effectively disabled flag of the button.
+     * @return generated style class.
+     */
+    protected String generateStyleClass(boolean disabled) {
+        StringBuilder styleClass = new StringBuilder(disabled ? "of-button-disabled" : "of-button");
+        String styleClassAttribute = getStyleClass();
+        if (styleClassAttribute != null) {
+            styleClassAttribute = styleClassAttribute.trim();
+            if (!styleClassAttribute.equals("")) {
+                styleClass.append(" ").append(styleClassAttribute);
+            }
+        }
+        return styleClass.toString();
+    }
+
+    /**
+     * Try to resolve a navigation case for the outcome of the current
+     * <code>Button</code> component.
+     *
+     * @param context <code>FacesContext</code> instance.
+     * @return <code>NaigationCase</code> for the outcome of the current
+     * <code>Button</code> component or <code>null</code> if navigation case
+     * couldn't be resolved.
+     */
+    protected NavigationCase getNavigationCase(FacesContext context) {
+        ConfigurableNavigationHandler navigationHandler = (ConfigurableNavigationHandler) context.getApplication().getNavigationHandler();
+        String outcome = getOutcome();
+        if (outcome == null) {
+            outcome = context.getViewRoot().getViewId();
+        }
+        NavigationCase navigationCase;
+        String toFlowDocumentId = (String)getAttributes().get(ActionListener.TO_FLOW_DOCUMENT_ID_ATTR_NAME);
+        if (toFlowDocumentId != null) {
+            navigationCase = navigationHandler.getNavigationCase(context, null, outcome, toFlowDocumentId);
+        } else {
+            navigationCase = navigationHandler.getNavigationCase(context, null, outcome);
+        }
+        return navigationCase;
+    }
+
+    /**
+     * Check if at least one <code>PathParam</code> was declared as a child
+     * of current component and is active or whether path parameter rendering, 
+     * including strict one, was turned off.
+     *
+     * @return <code>true</code> if at least one <code>PathParam</code> has
+     * to be rendered as a path parameter and <code>false</code> otherwise.
+     */
+    protected boolean hasDeclaredActivePathParams() {
+        return (getBasic() || !getForce() || getChildCount() == 0) ? false : 
+                getChildren().stream().anyMatch(Button::isActivePathParameter);
+    }
+    
+    /**
+     * Define if <code>MultiView</code> was configured for the target view id of
+     * the <code>NavigationCase</code>.
+     *
+     * @param context <code>FacesContext</code> instance.
+     * @param navigationCase <code>NavigationCase</code> for which presence of
+     * <code>MultiView</code> configuration has to be determined.
+     * @return <code>true</code> if <code>MultiView</code> was configured for
+     * the target view id of the <code>NavigationCase</code> and
+     * <code>false</code> otherwise.
+     */
+    protected boolean isMultiViewsEnabled(FacesContext context, NavigationCase navigationCase) {
+        //TODO integrate better with Faces Views
+        //A fix of this method would be: (1) to change visibility of method
+        //FacesViews#isMultiViewsEnabled(ServletContext servletContext, String resource)
+        //from package access to public and (2) modify the code to:
+        //String resource = navigationCase.getToViewId(context);
+        //resource = resource.substring(0, resource.lastIndexOf("."));
+        //return FacesViews#isMultiViewsEnabled(context.getExternalContext().getContext(), resource);
+        String resource = navigationCase.getToViewId(context);
+        resource = resource.substring(0, resource.lastIndexOf("."));
+        Set<String> multiviewsPaths = getApplicationAttribute((ServletContext) context.getExternalContext().getContext(), "org.omnifaces.facesviews.multiviews_paths");
+        if (multiviewsPaths != null) {
+            String path = resource + "/";
+            for (String multiviewsPath : multiviewsPaths) {
+                if (path.startsWith(multiviewsPath)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Writes defined attributes of the current component with the specified writer.
+     * 
+     * @param writer <code>ResponseWriter</code> to write component attributes with.
+     * @throws RuntimeException that wraps <code>IOException</code>
+     */
+    protected void writeButtonAttributes(ResponseWriter writer) {
+        Map<String, Object> attrs = getAttributes();//must call get on this map to evaluate property
+        ATTRIBUTE_NAMES.entrySet().stream()
+                .forEach(consumerRethrower((attr) -> {
+                    Object attrVal = attrs.get(attr.getKey());
+                    String value = attrVal == null ? null : attrVal.toString();
+                    if(value != null) writer.writeAttribute(attr.getKey(), value, attr.getValue());
+                }));
+    }
+
+    /**
+     * Writes defined pass through attributes of the current component with the specified writer.
+     * 
+     * @param context <code>FacesContext</code> instance.
+     * @param writer <code>ResponseWriter</code> to write pass through attributes with.
+     * @throws RuntimeException that wraps <code>IOException</code>
+     */
+    protected void writePassthroughAttrs(FacesContext context, ResponseWriter writer) {
+        Map<String, Object> passthroughAttrs = getPassThroughAttributes(false);
+        if (passthroughAttrs != null && !passthroughAttrs.isEmpty()) {
+            passthroughAttrs.entrySet().stream()
+                    .forEach(consumerRethrower((attr) -> {
+                        Object attrVal = attr.getValue();
+                        Object attrValEv = attrVal instanceof ValueExpression ? ((ValueExpression)attrVal).getValue(context.getELContext()) : attrVal;
+                        String value = attrValEv == null ? null : attrValEv.toString();
+                        if(value != null) writer.writeAttribute(attr.getKey(), value, null);
+                    }));
+        }
+    }
+
+    /**
+     * Writes the value of this component with <code>ResponseWriter</code>,
+     * escaping content by default and not escaping it if escape attribute was
+     * explicitly set to false.
+     * 
+     * @param writer <code>ResponseWriter</code> to write component attributes with.
+     * @throws IOException 
+     */
+    protected void writeValue(ResponseWriter writer) throws IOException {
+        Object value = getValue();
+        if (value != null) {
+            if (getEscape()) {
+                writer.writeText(value, "value");
+            } else {
+                writer.write(value.toString());
+            }
+        } else {
+            writer.write("Button");
+        }
+    }
+
+    /**
+     * Generate bookmarkable URL for the <code>NavigationCase</code> with query and 
+     * path parameters gathered from nested <code>UIParameter</code> instances.
+     * <code>ViewHandler::getBookmarkableURL</code> method is used to generate standard
+     * bookmarkable URL and path fragment generated from <code>PathParam</code>
+     * instances is added to that URL.
+     * 
+     * @param context <code>FacesContext</code> instance.
+     * @param navigationCase <code>NavigationCase</code> where to create URL for.
+     * @param isMultiViewId whether the destination view is a valid multi view id.
+     * @return bookmarkable URL for the current component.
+     */
+    protected String createTargetURL(FacesContext context, NavigationCase navigationCase, boolean isMultiViewId) {
+        Map<Integer, List<String>> pathParams = new LinkedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+
+        fillDeclaredParams(pathParams, queryParams, isMultiViewId);
+        addNavigationCaseParameters(navigationCase, queryParams);
+        
+        String href = getBaseBookmarkableURL(context, navigationCase, queryParams);
+        
+        if (!pathParams.isEmpty()) {
+            String pathAddOn = generatePathFromParameters(pathParams);
+            int querySeparator = href.indexOf("?");
+            int index = querySeparator == -1 ? href.length() : querySeparator;
+            href = new StringBuilder(href).insert(index, pathAddOn).toString();
+        }
+        if (getFragment() != null) {
+            href += "#" + encodeURL(getFragment());
+        }
+        
+        return href;
+    }
+
+    // Private methods
+    /**
+     * Fill specified maps with values of nested <code>UIParameter</code> values.
+     * 
+     * @param pathParams map of found path parameter values.
+     * @param queryParams map of found query parameter values.
+     * @param isMultiViewId whether the destination view is a valid multi view id.
+     */
+    private void fillDeclaredParams(final Map<Integer, List<String>> pathParams, final Map<String, List<String>> queryParams, boolean isMultiViewId) {
+        if (getChildCount() > 0) {
+            if(!getBasic()) {
+                List<PathParam> pathParamsRaw = new ArrayList<>();
+                boolean treatAsSimpleParams = !isMultiViewId && !getForce();
+
+                for (UIComponent kid : getChildren()) {
+                    boolean handled = false;
+
+                    if (kid instanceof PathParam) {
+                        PathParam param = (PathParam) kid;
+                        if(!treatAsSimpleParams && !param.isDisable() && !param.getBasic()) {
+                            pathParamsRaw.add(param);
+                            handled = true;
+                        }
+                    }
+
+                    if (kid instanceof UIParameter && !handled) {
+                        UIParameter uiParam = (UIParameter) kid;
+                        if (!uiParam.isDisable()) {
+                            String name = uiParam.getName();
+                            Object value = uiParam.getValue();
+                            if (name != null) {
+                                name = name.trim();
+                                List<String> values = queryParams.get(name);
+                                if (values == null) {
+                                    values = new ArrayList<>();
+                                    queryParams.put(name, values);
+                                }
+                                values.add(value instanceof String ? (String)value : value.toString());
+                            }
+                        }
+                    }
+
+                }
+
+                if(!pathParamsRaw.isEmpty()) {
+                    Integer properIndex = 0;
+                    if(pathParamsRaw.stream().anyMatch(param -> param.getIndex() == null)) {
+                        String emptyPositionString = getLocation();
+                        Set<Integer> vals = pathParamsRaw.stream()
+                                .filter(param -> param.getIndex() != null)
+                                .map(param -> param.getIndex())
+                                .distinct().collect(Collectors.toSet());
+                        if ("end".equalsIgnoreCase(emptyPositionString)) {
+                            Optional<Integer> index = vals.stream().max(Integer::compare);
+                            properIndex = index.isPresent() ? index.get() + 1 : 0;
+                        } else if ("beginning".equalsIgnoreCase(emptyPositionString)) {
+                            Optional<Integer> index = vals.stream().min(Integer::compare);
+                            properIndex = index.isPresent() ? index.get() - 1 : 0;
+                        } else {
+                            try {
+                                properIndex = Integer.valueOf(emptyPositionString);
+                            } catch (NumberFormatException nfe) {
+                                Optional<Integer> index = vals.stream().max(Integer::compare);
+                                properIndex = index.isPresent() ? index.get() + 1 : 0;
+                            }
+                        }
+                    }
+
+                    final Integer ind = properIndex == null ? 0 : properIndex;
+                    Map<Integer, List<String>> pathParamsMap = pathParamsRaw.stream()
+                            .collect(Collectors.groupingBy(param -> { Integer index = param.getIndex(); return index == null ? ind : index; }, 
+                                    HashMap::new, 
+                                    Collectors.mapping(param -> { Object val = param.getValue(); return val == null ? null : val.toString(); },
+                                            Collectors.toCollection(ArrayList::new))));
+
+                    pathParams.putAll(pathParamsMap);
+                }
+            } else {
+                for (UIComponent kid : getChildren()) {
+                    if (kid instanceof UIParameter) {
+                        UIParameter uiParam = (UIParameter) kid;
+                        if (!uiParam.isDisable()) {
+                            String name = uiParam.getName();
+                            Object value = uiParam.getValue();
+                            if (name != null) {
+                                name = name.trim();
+                                List<String> values = queryParams.get(name);
+                                if (values == null) {
+                                    values = new ArrayList<>();
+                                    queryParams.put(name, values);
+                                }
+                                values.add(value instanceof String ? (String)value : value.toString());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Add found navigation case parameters to a current query parameters map.
+     * 
+     * @param navigationCase <code>NavigationCase</code> where to look for navigation parameters.
+     * @param queryParams map with query parameters to add found navigation parameters to.
+     */
+    private void addNavigationCaseParameters(NavigationCase navigationCase, Map<String, List<String>> queryParams) {
+        Map<String, List<String>> navigationParameters = navigationCase.getParameters();
+        if (navigationParameters != null && !navigationParameters.isEmpty()) {
+            for (Map.Entry<String, List<String>> entry : navigationParameters.entrySet()) {
+                String name = entry.getKey();
+                //do not overwrite explicitly defined parameters
+                if (!queryParams.containsKey(name)) {
+                    List<String> values = entry.getValue();
+                    if (values.size() == 1) {
+                        String value = values.get(0);
+                        String sanitized = null != value && 2 < value.length() ? value.trim() : "";
+                        if (sanitized.contains("#{") || sanitized.contains("${")) {
+                            FacesContext context = FacesContext.getCurrentInstance();
+                            value = context.getApplication().evaluateExpressionGet(context, value, String.class);
+                            queryParams.put(name, Arrays.asList(value));
+                        } else {
+                            queryParams.put(name, values);
+                        }
+                    } else {
+                        queryParams.put(name, values);
+                    }
+                }
+            }
+        }
+        String toFlowDocumentId = navigationCase.getToFlowDocumentId();
+        if (toFlowDocumentId != null) {
+            List<String> flowDocumentIdValues = new ArrayList<>();
+            flowDocumentIdValues.add(toFlowDocumentId);
+            queryParams.put(FlowHandler.TO_FLOW_DOCUMENT_ID_REQUEST_PARAM_NAME, flowDocumentIdValues);
+            if (!FlowHandler.NULL_FLOW.equals(toFlowDocumentId)) {
+                List<String> flowIdValues = new ArrayList<>();
+                flowIdValues.add(navigationCase.getFromOutcome());
+                queryParams.put(FlowHandler.FLOW_ID_REQUEST_PARAM_NAME, flowIdValues);
+            }
+        }
+    }
+    
+    /**
+     * Generate bookmarkable URL for the <code>NavigationCase</code> with supplied 
+     * query parameters by a call to <code>ViewHandler::getBookmarkableURL</code> method.
+     * 
+     * @param context <code>FacesContext</code> instance. 
+     * @param navigationCase current <code>NavigationCase</code>.
+     * @param params query parameters to be added to the generated URL.
+     * @return generated bookmarkable URL with query parameters.
+     */
+    private String getBaseBookmarkableURL(FacesContext context, NavigationCase navigationCase, Map<String, List<String>> params) {
+        String href;
+        String toViewId = navigationCase.getToViewId(context);
+        boolean isIncludeViewParams = isIncludeViewParams() || navigationCase.isIncludeViewParams();
+
+        boolean clientWindowRenderingEnabled = false;
+        ClientWindow clientWindow = null;
+        try {
+            if (isDisableClientWindow()) {
+                clientWindow = context.getExternalContext().getClientWindow();
+                if (clientWindow != null) {
+                    clientWindowRenderingEnabled = clientWindow.isClientWindowRenderModeEnabled(context);
+                    if (clientWindowRenderingEnabled) {
+                        clientWindow.disableClientWindowRenderMode(context);
+                    }
+                }
+            }
+            ViewHandler viewHandler = context.getApplication().getViewHandler();
+            href = viewHandler.getBookmarkableURL(context, toViewId, params, isIncludeViewParams);
+        } finally {
+            if (clientWindowRenderingEnabled && clientWindow != null) {
+                clientWindow.enableClientWindowRenderMode(context);
+            }
+        }
+        return href;
+    }
+    
+    /**
+     * Generate URI-encoded path from supplied path parameters.
+     * 
+     * @param pathParams path parameters to extract values from.
+     * @return URI-encoded path value.
+     */
+    private String generatePathFromParameters(Map<Integer, List<String>> pathParams) {
+        List<List<String>> params = pathParams.entrySet().stream()
+                .sorted(Comparator.comparing(Map.Entry::getKey))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+        String path = params.stream()
+                .flatMap(List::stream)
+                .filter(g -> g != null && !"".equals(g))
+                .map(g -> encodeURI(g))
+                .collect(Collectors.joining("/"));
+        return "".equals(path) ? "" : "/" + path;
+    }
+    
+    // Helpers
+    /**
+     * Collect all attributes of the component that should be rendered.
+     * 
+     * @return unmodifiable map that contains all attributes of the component
+     * that should be rendered.
+     */
+    private static Map<String, String> getButtonAttributes() {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("accesskey", "accesskey");
+        attrs.put("alt", "alt");
+        attrs.put("dir", "dir");
+        attrs.put("lang", "lang");
+        attrs.put("onblur", "blur");
+        attrs.put("onclick", "click");
+        attrs.put("ondblclick", "dblclick");
+        attrs.put("onfocus", "focus");
+        attrs.put("onkeydown", "keydown");
+        attrs.put("onkeypress", "keypress");
+        attrs.put("onkeyup", "keyup");
+        attrs.put("onmousedown", "mousedown");
+        attrs.put("onmousemove", "mousemove");
+        attrs.put("onmouseout", "mouseout");
+        attrs.put("onmouseover", "mouseover");
+        attrs.put("onmouseup", "mouseup");
+        attrs.put("role", "role");
+        attrs.put("style", "style");
+        attrs.put("tabindex", "tabindex");
+        attrs.put("title", "title");
+        return Collections.unmodifiableMap(attrs);
+    }
+
+    /**
+     * Functional interface that declares <code>Consumer</code> method that 
+     * throws <code>Exception</code>.
+     * 
+     * @param <T> input type.
+     * @param <E> exception type.
+     */
+    @FunctionalInterface
+    public interface ConsumerChecked<T, E extends Exception> {
+        void accept(T t) throws E;
+    }
+
+    /**
+     * Rethrow a checked <code>Exception</code> by wrapping it in a 
+     * <code>RuntimeException</code>.
+     * 
+     * @param <T> input type.
+     * @param <E> exception type.
+     * @param consumerChecked consumerChecked instance.
+     * @return wrapped <code>Consumer</code> functional interface.
+     */
+    public static <T, E extends Exception> Consumer<T> consumerRethrower(ConsumerChecked<T, E> consumerChecked) {
+        return i -> {
+            try {
+                consumerChecked.accept(i);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        };
+    }
+
+    /**
+     * Check if a component is an active path parameter.
+     * 
+     * @param component UIComponent to check.
+     * @return <code>true</code> if parameter is an active path parameter and
+     * <code>false</code> otherwise.
+     */
+    public static boolean isActivePathParameter(UIComponent component) {
+        return component instanceof PathParam && !((PathParam) component).isDisable() && !((PathParam) component).getBasic(); // rendered not taken into account
+    }
+
+    /**
+     * Adds a <code>FacesMessage</code> with severity <code>SEVERITY_WARN</code>
+     * to the <code>FacesContext</code>.
+     * 
+     * @param context <code>FacesContext</code> to add message to.
+     * @param message <code>FacesMessage</code> to be added.
+     */
+    public static void addFacesWarnMessage(FacesContext context, String message) {
+        FacesMessage msg = new FacesMessage(message);
+        msg.setSeverity(FacesMessage.SEVERITY_WARN);
+        context.addMessage(null, msg);
+    }
+    
+}

--- a/src/main/java/org/omnifaces/component/output/Link.java
+++ b/src/main/java/org/omnifaces/component/output/Link.java
@@ -1,0 +1,874 @@
+/*
+ * Copyright 2017 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.component.output;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import javax.el.ValueExpression;
+//import javax.faces.FacesException;
+import javax.faces.application.ConfigurableNavigationHandler;
+import javax.faces.application.FacesMessage;
+import javax.faces.application.NavigationCase;
+import javax.faces.application.ProjectStage;
+import javax.faces.application.ViewHandler;
+import javax.faces.component.FacesComponent;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UIParameter;
+import javax.faces.component.html.HtmlOutcomeTargetLink;
+import javax.faces.context.FacesContext;
+import javax.faces.context.ResponseWriter;
+import javax.faces.event.ActionListener;
+import javax.faces.event.PreRenderComponentEvent;
+import javax.faces.flow.FlowHandler;
+import javax.faces.lifecycle.ClientWindow;
+import javax.servlet.ServletContext;
+
+import static org.omnifaces.util.Renderers.writeIdAttributeIfNecessary;
+import static org.omnifaces.util.Servlets.getApplicationAttribute;
+import static org.omnifaces.util.Utils.encodeURI;
+import static org.omnifaces.util.Utils.encodeURL;
+
+/**
+ * The <code>&lt;o:link&gt;</code> is a component that extends the standard <code>&lt;h:link&gt;</code> component to support 
+ * <code>MultiViews</code> feature of {@link org.omnifaces.facesviews.FacesViews} by rendering the supplied <code>&lt;o:pathParam&gt;</code>
+ * parameters as path parameters and not as query parameters as otherwise will be produced by standard <code>&lt;o:param&gt;</code> and 
+ * <code>&lt;f:param&gt;</code>, or if <code>&lt;o:pathParam&gt;</code> tags are nested in a standard <code>&lt;h:link&gt;</code>.
+ * <p>
+ * To achieve this goal <code>&lt;o:pathParam&gt;</code> tags must be specified as children of <code>&lt;o:link&gt;</code>. See {@link PathParam}
+ * for an overview of configuration of path parameters. Any <code>&lt;o:pathParam&gt;</code> tag will be rendered as a part of the URL path of 
+ * this component, like <i>/path-parameter-evaluated-value</i>, if the following conditions are met:
+ * <ol>
+ * <li>
+ * <code>outcome</code> attribute of the current <code>&lt;o:link&gt;</code> component specifies a valid MultiView page, 
+ * see {@link org.omnifaces.facesviews.FacesViews} for a proper way of configuring <code>MultiViews</code> feature.
+ * </li>
+ * <li>
+ * <code>basic</code> attribute of the current component must evaluate to false (or left as default).
+ * </li>
+ * <li>
+ * <code>basic</code> attribute of <code>&lt;o:pathParam&gt;</code> tag must evaluate to false (or left as default).
+ * </li>
+ * </ol>
+ * <p>
+ * The ordering of path parameters will be defined according to the <code>index</code> attribute of <code>&lt;o:pathParam&gt;</code> tags. 
+ * In case of collisions the tags with equal indices, either specified and unspecified, will be rendered in the order they were defined. 
+ * The location of paths with unspecified indices will be derived from <code>location</code> attribute of this component, see description below. 
+ * Location and indices only specify relative context of rendering, or before-after relation. Negative indices are also supported.
+ * <p>
+ * This component also accepts standard parameters, <code>&lt;o:param&gt;</code> and <code>&lt;f:param&gt;</code>, and will render
+ * them as query parameters, as it has always traditionally been done by {@link UIOutcomeTarget} components like <code>&lt;h:link&gt;</code> and 
+ * <code>&lt;h:button&gt;</code>. <code>&lt;o:pathParam&gt;</code> tags can also be rendered as query parameters if their <code>basic</code>
+ * attributes evaluate to true. It can be helpful if an application has to decide upon way of rendering at runtime, by checking 
+ * <code>#{someCondition}</code>.
+ * <p>
+ * The component specifies three additional non-required attributes to control and fine-tune the generated path from path parameters:
+ * <ul>
+ * <li>
+ * <code>location</code>, non-required attribute that defines the location where <code>&lt;o:pathParam&gt;</code> tags with non-specified 
+ * <code>index</code> attributes relative to the ones with the specified <code>index</code> attribute will be rendered: after all path 
+ * parameters for attribute value "end", before all path parameters for attribute value "beginning" or at a specified location for attribute 
+ * integer value, i.e. for components where <code>Integer.valueOf(getLocation())</code> doesn't throw <code>NumberFormatException</code>. 
+ * Default value of this attribute is "end". All other values will be treated as "end" as well.
+ * </li>
+ * <li>
+ * <code>force</code>, non-required attribute that defines behaviour when <code>outcome</code> attribute doesn't specify a valid MultiView page:
+ * if the attribute value is true then if any <code>&lt;o:pathParam&gt;</code> with <code>basic</code> attribute evaluating to false are present 
+ * the component will be rendered as disabled and generate a {@link FacesMessage} that the outcome is not a valid MultiView page, if the 
+ * attribute value is false, any <code>&lt;o:pathParam&gt;</code> tag will be treated as simple <code>&lt;o:param&gt;</code> thus producing 
+ * query parameters for all parameters with a specified non-empty name. Default value is true.
+ * </li>
+ * <li>
+ * <code>basic</code>, non-required attribute that is used to turn off dealing with <code>&lt;o:pathParam&gt;</code> tags as path parameters.
+ * If this property evaluates to true, all present <code>&lt;o:pathParam&gt;</code> tags will be treated as <code>&lt;o:param&gt;</code> tags,
+ * thus overriding all preset behaviour of the component and its children. If this property evaluates to false, the rendering will proceed
+ * in a standard fashion, described above. This attribute is helpful when an application needs to turn off defined behaviour basing on
+ * some condition. Default value is false.
+ * </li>
+ * </ul>
+ * <p>
+ * There are two additional properties to the ones defined in <code>&lt;h:link&gt;</code> to account for extra features: 
+ * <ul>
+ * <li>
+ * <code>fragment</code>, non-required attribute that attaches hash-separated fragment at the end of the URL, if present and not empty.
+ * </li>
+ * <li>
+ * <code>escape</code>, non-required attribute that defines whether or not to escape the value of this component. Default value is true.
+ * Beware of potential XSS attack holes when redisplaying user-controlled input with <code>escape="false"</code>.
+ * </li>
+ * </ul>
+ * <p>
+ * This component is useful when application must provide links to the MultiView-configured pages with parameters rendered as part of the 
+ * path and not a part of the query string, as it is traditionally done. The sending page defines a <code>&lt;o:link&gt;</code> with 
+ * <code>&lt;o:pathParam&gt;</code>s, thus generating URL with path parameters, and the receiving page consumes these path parameters in 
+ * CDI beans by means of {@link org.omnifaces.cdi.Param} with a specified <code>pathIndex</code> property.
+ * <p>
+ * There are some options, described above, for tuning the generated URL of this component in various circumstances. This component 
+ * can also be used to generate standard links for non-MultiView pages as well as links for MultiView pages with standard appearance.
+ * <p>
+ * The component provides predefined CSS classes to support defining styles for all used components of this type in ones place. Additionally,
+ * user-defined CSS classes can be added via the traditional <code>styleClass</code> attribute. All active links, i.e. those links that are not disabled, 
+ * have a proper outcome and satisfy the requirements for the <code>MultiViews</code> mentioned above, will be rendered as <code>a</code> HTML elements.
+ * All disabled links, i.e. the links that don't satisfy any of the requirement for active links, will be rendered as <code>span</code> HTML elements.
+ * As nesting children is allowed for the link component and it is the application responsibility to create right HTML structure for proper
+ * appearance of the link. Also note that both the value of the component and its children, if present, will be rendered to HTML output, so 
+ * this must be taken into account when developing applications. It is recommended either to use the value and don't have any rendered children 
+ * or leave the value blank and have content by rendering children, though this approach isn't enforced by the component.
+ * These classes are:
+ * <ul>
+ * <li>"of-link" for all generated <code>a</code> HTML elements reflecting active links.</li>
+ * <li>"of-link-disabled" for all generated <code>span</code> HTML elements reflecting disabled links.</li>
+ * </ul>
+ * <p>
+ * Basic usage examples follow. They assume that {@link org.omnifaces.facesviews.FacesViews} is turned on and <code>MultiViews</code>
+ * configuration is present for paths "/users/*", "/path/*" and "/blog/*":
+ * <pre>
+ * &lt;context-param&gt;
+ *     &lt;param-name&gt;org.omnifaces.FACES_VIEWS_SCAN_PATHS&lt;/param-name&gt;
+ *     &lt;param-value&gt;/*.xhtml, /user/*, /path/*, /blog/*&lt;/param-value&gt;
+ * &lt;/context-param&gt;
+ * </pre>
+ * For additional information on how to configure FacesViews and use the MutiViews feature see {@link org.omnifaces.facesviews.FacesViews}.
+ * <p>
+ * In the following example the component generates a link to a view user detail page by employing implicit <code>@FacesConverter(forClass)</code>
+ * converter.
+ * <pre>
+ * &lt;o:link value="User details" outcome="user"&gt;
+ *     &lt;o:pathParam&gt; value="#{bean.user}" /&gt;
+ * &lt;/o:link&gt;
+ * </pre>
+ * with
+ * <pre>
+ *{@literal @}FacesConverter(forClass = User.class) public class UserConverter implements Converter {
+ *     public Object getAsObject(FacesContext context, UIComponent component, String value) {
+ *         if (value == null) { return null; } return new User(value);
+ *     }
+ *     public String getAsString(FacesContext context, UIComponent component, Object value) {
+ *         if(value == null) { return ""; }
+ *         if(value instanceof User) { User user = (User)value; return user.getUsername(); }
+ *         throw new ConverterException(value + " not a User");
+ *     }
+ * }
+ *{@literal @}Named @RequestScoped public class Bean { private User user; ... }
+ * public class User { private String username; ... }
+ * </pre>
+ * The generated URL could look like <code>/context-path/user/username</code>.
+ * <p>
+ * The following link shows a way of tuning the rendering of path parameters.
+ * <pre>
+ * &lt;o:link value="Link" outcome="path" location="beginning"&gt;
+ *     &lt;o:pathParam&gt; value="first" index="1"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="no-index"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="basic" value="basic" basic="true"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="third" index="3"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="no-index-second" disable="#{someCondition}"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="#{bean.name}" converter="#{bean}" index="2"&lt;/o:pathParam&gt;
+ * &lt;/o:link&gt;
+ * </pre>
+ * The generated URL could look like <code>/context-path/path/no-index/no-index-second/first/bean-name/third?basic=basic</code>.
+ * <p>
+ * Note that if the outcome of the link above pointed at a standard view id, say, <code>index</code> then the construct will
+ * be rendered as a disabled link (impossible to render path parameters at a standard outcome). Still, configuring
+ * &lt;o:link ... force="false" /&gt; will render an active link with all of the parameter rendered as query parameters (for 
+ * parameters with non-empty name). Also note that standard parameters are perfectly legal:
+ * <pre>
+ * &lt;o:link ...&gt;
+ *     &lt;o:pathParam&gt; ...&lt;/o:pathParam&gt;
+ *     &lt;o:param&gt; name="omniparam" value="omniparam"&lt;/o:param&gt;
+ *     &lt;f:param&gt; name="fparam" value="fparam"&lt;/f:param&gt;
+ * &lt;/o:link&gt;
+ * </pre>
+ * Another option to turn off rendering of path parameters altogether is to set a condition for the <code>basic</code> attribute:
+ * <pre>
+ * &lt;o:link value="Link" outcome="path" basic="#{someCondition}"&gt;
+ *     &lt;o:pathParam&gt; name="first" value="first"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="second" value="second"&lt;/o:pathParam&gt;
+ * &lt;/o:link&gt;
+ * </pre>
+ * If <code>#{someCondition}</code> evaluates to false, the URL will be rendered as <code>/context-path/path/first/second</code>,
+ * and if it evaluates to true, the URL will be rendered as <code>/context-path/path?first=first&second=second</code>.
+ * <p>
+ * The significant benefit of using the <code>&lt;o:link&gt;</code> component is its ability to integrate with JSF infrastructure.
+ * The <code>outcome</code> attribute will be internally checked by a {@link NavigationHandler} and {@link ViewHandler} 
+ * and in case of negative result the component will be rendered as disabled and a message will be printed. On the one hand this 
+ * will reduce the number of hand-written errors and on the other hand will incorporate all user-created artifacts, like custom
+ * <code>ViewHandlerWrapper</code> classes with overridden <code>getActionURL(...)</code> methods to reflect and generate valid 
+ * and up-to-date URLs for output components.
+ * <p>
+ * The following component, for example, will be rendered as disabled: <code>&lt;o:link outcome="non-existing-path" .../&gt;</code>.
+ * <p>
+ * The following component will render a link with a prefix, if <code>getActionURL(...)</code> were overridden accordingly to prefix 
+ * all paths of a special subset of views to "/special": <code>&lt;o:link outcome="special-path-for-view-handler" .../&gt;</code>. 
+ * The generated URL could look like <code>/context-path/special/special-path-for-view-handler/...</code>.
+ * <p>
+ * The last example renders URLs basing on available information. For example, we can have a mapping on "/blog" with year, month and 
+ * day specified. The following link could be used to point at a valid blog post overview:
+ * <pre>
+ * &lt;o:link value="Blog" outcome="blog"&gt;
+ *     &lt;o:pathParam&gt; name="year" value="#{userSettings.year}"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="month" value="#{userSettings.month}"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="day" value="#{userSettings.day}"&lt;/o:pathParam&gt;
+ * &lt;/o:link&gt;
+ * </pre>
+ * Of course, some additional logic must be incorporated to check parameters, but the construct above could be used to render links
+ * with URLs of type <code>/context-path/blog/2017</code>, <code>/context-path/blog/2017/october</code> and 
+ * <code>/context-path/blog/2017/october/1</code>, which could be rather fruitful under some circumstances.
+ * 
+ * @author Sergey Kuntsel
+ * @since 3.0
+ * @see Button
+ * @see PathParam
+ */
+@FacesComponent(Link.COMPONENT_TYPE)
+public class Link extends HtmlOutcomeTargetLink {
+    //TODO refactor in favour of a Renderer or create a Utility class to solve common tasks.
+
+    // Constants
+    public static final String COMPONENT_TYPE = "org.omnifaces.component.output.Link";
+    public static final String COMPONENT_FAMILY = "org.omnifaces.component.output";
+
+    // TODO externalize messages and add i18n support
+    private static final String ERROR_NAVIGATION_CASE_NOT_FOUND =
+            "Navigation case couldn't be resolved for the outcome: %s.";
+    private static final String ERROR_MULTIVIEW_NOT_CONFIGURED =
+            "MultiView was not configured for the outcome: %s, but PathParams were defined for it.";
+    private static final String NO_NAVIGATION_CASE = Link.class.getName() + "_NO_NAVIGATION_CASE";
+    private static final String NO_MULTIVIEW_CONFIG = Link.class.getName() + "_NO_MULTIVIEW_CONFIG";
+
+    private static final Logger logger = Logger.getLogger(Link.class.getName());
+    protected static final Map<String, String> ATTRIBUTE_NAMES = getLinkAttributes();
+
+    // Constructor
+    public Link() {
+        setRendererType(null);
+    }
+
+    // Properties
+    private enum PropertyKeys {
+        fragment, // attach hash-separated fragment at the end of the URL, default null
+        escape, // escape content if explicitly needed, default true
+        location, // location to render path params with unspecified index: at the beginning ("beginning"), at the end ("end") or at the specified index (any Integer value)
+                  //default value "end", any other string and error while converting to Integer equals to "end"
+        force, // if true: when PathParams defined for non-applicable view generate error message, if false: treat PathParams as UIParameters, default true
+        basic; // if true: all PathParams will be treated as UIParameters, thus effectively disabling path parameter behaviour basing on some condition, if false: standard behaviour, default false
+    }
+
+    public String getFragment() { return (String)getStateHelper().eval(PropertyKeys.fragment); }
+    public void setFragment(String fragment) { getStateHelper().put(PropertyKeys.fragment, fragment); }
+    public Boolean getEscape() { return (Boolean)getStateHelper().eval(PropertyKeys.escape, Boolean.TRUE); }
+    public void setEscape(Boolean escape) { getStateHelper().put(PropertyKeys.escape, escape); }
+    public String getLocation() { return (String)getStateHelper().eval(PropertyKeys.location, "end"); }
+    public void setLocation(String location) { getStateHelper().put(PropertyKeys.location, location); }
+    public Boolean getForce() { return (Boolean)getStateHelper().eval(PropertyKeys.force, Boolean.TRUE); }
+    public void setForce(Boolean escape) { getStateHelper().put(PropertyKeys.force, escape); }
+    public Boolean getBasic() { return (Boolean)getStateHelper().eval(PropertyKeys.basic, Boolean.FALSE); }
+    public void setBasic(Boolean basic) { getStateHelper().put(PropertyKeys.basic, basic); }
+
+    // Superclass overrides
+    @Override
+    public String getFamily() { return COMPONENT_FAMILY; }
+
+    @Override
+    public boolean getRendersChildren() { return false; }
+
+    // Encoding behaviour
+    @Override
+    public void encodeBegin(FacesContext context) throws IOException {
+        if (context == null) { throw new NullPointerException(); }
+        pushComponentToEL(context, null);
+        if (!isRendered()) { return; }
+        context.getApplication().publishEvent(context,PreRenderComponentEvent.class, this);
+
+        boolean disabled = isDisabled();
+        NavigationCase navigationCase = null;
+        boolean navigationCaseNotFound = false;
+        boolean isMultiViewId = false;
+        boolean multiViewIdNotConfigured = false;
+        if (!disabled) {
+            navigationCase = getNavigationCase(context);
+            if(navigationCase == null) {
+                navigationCaseNotFound = true;
+                context.getAttributes().put(NO_NAVIGATION_CASE, true);
+                //throw new FacesException(String.format(ERROR_NAVIGATION_CASE_NOT_FOUND, getOutcome()));
+            } else {
+                isMultiViewId = isMultiViewsEnabled(context, navigationCase);
+                multiViewIdNotConfigured = !isMultiViewId && hasDeclaredActivePathParams();
+                if (multiViewIdNotConfigured) {
+                    context.getAttributes().put(NO_MULTIVIEW_CONFIG, true);
+                    //throw new FacesException(String.format(ERROR_MULTIVIEW_NOT_CONFIGURED, getOutcome()));
+                }
+            }
+        }
+
+        boolean effectivelyDisabled = disabled || navigationCase == null || multiViewIdNotConfigured;
+
+        ResponseWriter writer = context.getResponseWriter();
+        
+        if (effectivelyDisabled) {
+            writer.startElement("span", this);
+        } else {
+            writer.startElement("a", this);
+        }
+        writeIdAttributeIfNecessary(writer, this);
+        writer.writeAttribute("name", getClientId(), "name");
+
+        String styleClass = generateStyleClass(effectivelyDisabled);
+        writer.writeAttribute("class", styleClass, "styleClass");
+
+        if (!effectivelyDisabled) {
+            String href = createTargetURL(context, navigationCase, isMultiViewId);
+            writer.writeAttribute("href", href, "outcome");
+        }
+        
+        writeLinkAttributes(writer);
+        writePassthroughAttrs(context, writer);
+        writeValue(writer);
+
+        if (!context.isProjectStage(ProjectStage.Production)) {
+            if (navigationCaseNotFound) {
+                String message = String.format(ERROR_NAVIGATION_CASE_NOT_FOUND, getOutcome());
+                // FacesMessage was already added via navigation handler
+                if (logger.isLoggable(Level.WARNING)) {
+                    logger.log(Level.WARNING, "{0} Component id: {1}.", new Object[]{message, getId()});
+                }
+            }
+            if (multiViewIdNotConfigured) {
+                String message = String.format(ERROR_MULTIVIEW_NOT_CONFIGURED, getOutcome());
+                addFacesWarnMessage(context, message);
+                if (logger.isLoggable(Level.WARNING)) {
+                    logger.log(Level.WARNING, "{0} Component id: {1}.", new Object[]{message, getId()});
+                }
+            }
+        }
+    }
+
+    @Override
+    public void encodeEnd(FacesContext context) throws IOException {
+        if (context == null) { throw new NullPointerException(); }
+        if (!isRendered()) { popComponentFromEL(context); return; }
+        ResponseWriter writer = context.getResponseWriter();
+        
+        boolean noNavigationCase = context.getAttributes().remove(NO_NAVIGATION_CASE) != null;
+        boolean noMultiViewConfig = context.getAttributes().remove(NO_MULTIVIEW_CONFIG) != null;
+        if (isDisabled() || noNavigationCase || noMultiViewConfig) {
+            writer.endElement("span");
+        } else {
+            writer.endElement("a");
+        }
+        
+        if (!context.isProjectStage(ProjectStage.Production)) {
+            String message = null;
+            if (noNavigationCase) {
+                message = String.format(ERROR_NAVIGATION_CASE_NOT_FOUND, getOutcome());
+            }
+            if (noMultiViewConfig) {
+                message = String.format(ERROR_MULTIVIEW_NOT_CONFIGURED, getOutcome());
+            }
+            if (message != null) {
+                writer.startElement("span", null);
+                writer.writeAttribute("style", "margin-left: 3px; color: #DC143C", null);
+                writer.write(message);
+                writer.endElement("span");            
+            }
+        }
+        
+        popComponentFromEL(context);
+    }
+
+    // Protected methods
+    /**
+     * Generate style class for the current link. Any active link has "of-link" class,
+     * any disabled link has "of-link-disabled" class. User-defined classes are 
+     * appended as well.
+     * 
+     * @param disabled effectively disabled flag of the link.
+     * @return generated style class.
+     */
+    protected String generateStyleClass(boolean disabled) {
+        StringBuilder styleClass = new StringBuilder(disabled ? "of-link-disabled" : "of-link");
+        String styleClassAttribute = getStyleClass();
+        if (styleClassAttribute != null) {
+            styleClassAttribute = styleClassAttribute.trim();
+            if (!styleClassAttribute.equals("")) {
+                styleClass.append(" ").append(styleClassAttribute);
+            }
+        }
+        return styleClass.toString();
+    }
+
+    /**
+     * Try to resolve a navigation case for the outcome of the current
+     * <code>Link</code> component.
+     *
+     * @param context <code>FacesContext</code> instance.
+     * @return <code>NaigationCase</code> for the outcome of the current
+     * <code>Link</code> component or <code>null</code> if navigation case
+     * couldn't be resolved.
+     */
+    protected NavigationCase getNavigationCase(FacesContext context) {
+        ConfigurableNavigationHandler navigationHandler = (ConfigurableNavigationHandler) context.getApplication().getNavigationHandler();
+        String outcome = getOutcome();
+        if (outcome == null) {
+            outcome = context.getViewRoot().getViewId();
+        }
+        NavigationCase navigationCase;
+        String toFlowDocumentId = (String)getAttributes().get(ActionListener.TO_FLOW_DOCUMENT_ID_ATTR_NAME);
+        if (toFlowDocumentId != null) {
+            navigationCase = navigationHandler.getNavigationCase(context, null, outcome, toFlowDocumentId);
+        } else {
+            navigationCase = navigationHandler.getNavigationCase(context, null, outcome);
+        }
+        return navigationCase;
+    }
+
+    /**
+     * Check if at least one <code>PathParam</code> was declared as a child
+     * of current component and is active or whether path parameter rendering, 
+     * including strict one, was turned off.
+     *
+     * @return <code>true</code> if at least one <code>PathParam</code> has
+     * to be rendered as a path parameter and <code>false</code> otherwise.
+     */
+    protected boolean hasDeclaredActivePathParams() {
+        return (getBasic() || !getForce() || getChildCount() == 0) ? false : 
+                getChildren().stream().anyMatch(Link::isActivePathParameter);
+    }
+    
+    /**
+     * Define if <code>MultiView</code> was configured for the target view id of
+     * the <code>NavigationCase</code>.
+     *
+     * @param context <code>FacesContext</code> instance.
+     * @param navigationCase <code>NavigationCase</code> for which presence of
+     * <code>MultiView</code> configuration has to be determined.
+     * @return <code>true</code> if <code>MultiView</code> was configured for
+     * the target view id of the <code>NavigationCase</code> and
+     * <code>false</code> otherwise.
+     */
+    protected boolean isMultiViewsEnabled(FacesContext context, NavigationCase navigationCase) {
+        //TODO integrate better with Faces Views
+        //A fix of this method would be: (1) to change visibility of method
+        //FacesViews#isMultiViewsEnabled(ServletContext servletContext, String resource)
+        //from package access to public and (2) modify the code to:
+        //String resource = navigationCase.getToViewId(context);
+        //resource = resource.substring(0, resource.lastIndexOf("."));
+        //return FacesViews#isMultiViewsEnabled(context.getExternalContext().getContext(), resource);
+        String resource = navigationCase.getToViewId(context);
+        resource = resource.substring(0, resource.lastIndexOf("."));
+        Set<String> multiviewsPaths = getApplicationAttribute((ServletContext) context.getExternalContext().getContext(), "org.omnifaces.facesviews.multiviews_paths");
+        if (multiviewsPaths != null) {
+            String path = resource + "/";
+            for (String multiviewsPath : multiviewsPaths) {
+                if (path.startsWith(multiviewsPath)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Writes defined attributes of the current component with the specified writer.
+     * 
+     * @param writer <code>ResponseWriter</code> to write component attributes with.
+     * @throws RuntimeException that wraps <code>IOException</code>
+     */
+    protected void writeLinkAttributes(ResponseWriter writer) {
+        Map<String, Object> attrs = getAttributes();//must call get on this map to evaluate property
+        ATTRIBUTE_NAMES.entrySet().stream()
+                .forEach(consumerRethrower((attr) -> {
+                    Object attrVal = attrs.get(attr.getKey());
+                    String value = attrVal == null ? null : attrVal.toString();
+                    if(value != null) writer.writeAttribute(attr.getKey(), value, attr.getValue());
+                }));
+    }
+
+    /**
+     * Writes defined pass through attributes of the current component with the specified writer.
+     * 
+     * @param context <code>FacesContext</code> instance.
+     * @param writer <code>ResponseWriter</code> to write pass through attributes with.
+     * @throws RuntimeException that wraps <code>IOException</code>
+     */
+    protected void writePassthroughAttrs(FacesContext context, ResponseWriter writer) {
+        Map<String, Object> passthroughAttrs = getPassThroughAttributes(false);
+        if (passthroughAttrs != null && !passthroughAttrs.isEmpty()) {
+            passthroughAttrs.entrySet().stream()
+                    .forEach(consumerRethrower((attr) -> {
+                        Object attrVal = attr.getValue();
+                        Object attrValEv = attrVal instanceof ValueExpression ? ((ValueExpression)attrVal).getValue(context.getELContext()) : attrVal;
+                        String value = attrValEv == null ? null : attrValEv.toString();
+                        if(value != null) writer.writeAttribute(attr.getKey(), value, null);
+                    }));
+        }
+    }
+
+    /**
+     * Writes the value of this component with <code>ResponseWriter</code>,
+     * escaping content by default and not escaping it if escape attribute was
+     * explicitly set to false.
+     * 
+     * @param writer <code>ResponseWriter</code> to write component attributes with.
+     * @throws IOException 
+     */
+    protected void writeValue(ResponseWriter writer) throws IOException {
+        Object value = getValue();
+        if (value != null) {
+            if (getEscape()) {
+                writer.writeText(value, "value");
+            } else {
+                writer.write(value.toString());
+            }
+        }
+    }
+
+    /**
+     * Generate bookmarkable URL for the <code>NavigationCase</code> with query and 
+     * path parameters gathered from nested <code>UIParameter</code> instances.
+     * <code>ViewHandler::getBookmarkableURL</code> method is used to generate standard
+     * bookmarkable URL and path fragment generated from <code>PathParam</code>
+     * instances is added to that URL.
+     * 
+     * @param context <code>FacesContext</code> instance.
+     * @param navigationCase <code>NavigationCase</code> where to create URL for.
+     * @param isMultiViewId whether the destination view is a valid multi view id.
+     * @return bookmarkable URL for the current component.
+     */
+    protected String createTargetURL(FacesContext context, NavigationCase navigationCase, boolean isMultiViewId) {
+        Map<Integer, List<String>> pathParams = new LinkedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+
+        fillDeclaredParams(pathParams, queryParams, isMultiViewId);
+        addNavigationCaseParameters(navigationCase, queryParams);
+        
+        String href = getBaseBookmarkableURL(context, navigationCase, queryParams);
+        
+        if (!pathParams.isEmpty()) {
+            String pathAddOn = generatePathFromParameters(pathParams);
+            int querySeparator = href.indexOf("?");
+            int index = querySeparator == -1 ? href.length() : querySeparator;
+            href = new StringBuilder(href).insert(index, pathAddOn).toString();
+        }
+        if (getFragment() != null) {
+            href += "#" + encodeURL(getFragment());
+        }
+        
+        return href;
+    }
+
+    // Private methods
+    /**
+     * Fill specified maps with values of nested <code>UIParameter</code> values.
+     * 
+     * @param pathParams map of found path parameter values.
+     * @param queryParams map of found query parameter values.
+     * @param isMultiViewId whether the destination view is a valid multi view id.
+     */
+    private void fillDeclaredParams(final Map<Integer, List<String>> pathParams, final Map<String, List<String>> queryParams, boolean isMultiViewId) {
+        if (getChildCount() > 0) {
+            if(!getBasic()) {
+                List<PathParam> pathParamsRaw = new ArrayList<>();
+                boolean treatAsSimpleParams = !isMultiViewId && !getForce();
+
+                for (UIComponent kid : getChildren()) {
+                    boolean handled = false;
+
+                    if (kid instanceof PathParam) {
+                        PathParam param = (PathParam) kid;
+                        if(!treatAsSimpleParams && !param.isDisable() && !param.getBasic()) {
+                            pathParamsRaw.add(param);
+                            handled = true;
+                        }
+                    }
+
+                    if (kid instanceof UIParameter && !handled) {
+                        UIParameter uiParam = (UIParameter) kid;
+                        if (!uiParam.isDisable()) {
+                            String name = uiParam.getName();
+                            Object value = uiParam.getValue();
+                            if (name != null) {
+                                name = name.trim();
+                                List<String> values = queryParams.get(name);
+                                if (values == null) {
+                                    values = new ArrayList<>();
+                                    queryParams.put(name, values);
+                                }
+                                values.add(value instanceof String ? (String)value : value.toString());
+                            }
+                        }
+                    }
+
+                }
+
+                if(!pathParamsRaw.isEmpty()) {
+                    Integer properIndex = 0;
+                    if(pathParamsRaw.stream().anyMatch(param -> param.getIndex() == null)) {
+                        String emptyPositionString = getLocation();
+                        Set<Integer> vals = pathParamsRaw.stream()
+                                .filter(param -> param.getIndex() != null)
+                                .map(param -> param.getIndex())
+                                .distinct().collect(Collectors.toSet());
+                        if ("end".equalsIgnoreCase(emptyPositionString)) {
+                            Optional<Integer> index = vals.stream().max(Integer::compare);
+                            properIndex = index.isPresent() ? index.get() + 1 : 0;
+                        } else if ("beginning".equalsIgnoreCase(emptyPositionString)) {
+                            Optional<Integer> index = vals.stream().min(Integer::compare);
+                            properIndex = index.isPresent() ? index.get() - 1 : 0;
+                        } else {
+                            try {
+                                properIndex = Integer.valueOf(emptyPositionString);
+                            } catch (NumberFormatException nfe) {
+                                Optional<Integer> index = vals.stream().max(Integer::compare);
+                                properIndex = index.isPresent() ? index.get() + 1 : 0;
+                            }
+                        }
+                    }
+
+                    final Integer ind = properIndex == null ? 0 : properIndex;
+                    Map<Integer, List<String>> pathParamsMap = pathParamsRaw.stream()
+                            .collect(Collectors.groupingBy(param -> { Integer index = param.getIndex(); return index == null ? ind : index; }, 
+                                    HashMap::new, 
+                                    Collectors.mapping(param -> { Object val = param.getValue(); return val == null ? null : val.toString(); },
+                                            Collectors.toCollection(ArrayList::new))));
+
+                    pathParams.putAll(pathParamsMap);
+                }
+            } else {
+                for (UIComponent kid : getChildren()) {
+                    if (kid instanceof UIParameter) {
+                        UIParameter uiParam = (UIParameter) kid;
+                        if (!uiParam.isDisable()) {
+                            String name = uiParam.getName();
+                            Object value = uiParam.getValue();
+                            if (name != null) {
+                                name = name.trim();
+                                List<String> values = queryParams.get(name);
+                                if (values == null) {
+                                    values = new ArrayList<>();
+                                    queryParams.put(name, values);
+                                }
+                                values.add(value instanceof String ? (String)value : value.toString());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Add found navigation case parameters to a current query parameters map.
+     * 
+     * @param navigationCase <code>NavigationCase</code> where to look for navigation parameters.
+     * @param queryParams map with query parameters to add found navigation parameters to.
+     */
+    private void addNavigationCaseParameters(NavigationCase navigationCase, Map<String, List<String>> queryParams) {
+        Map<String, List<String>> navigationParameters = navigationCase.getParameters();
+        if (navigationParameters != null && !navigationParameters.isEmpty()) {
+            for (Map.Entry<String, List<String>> entry : navigationParameters.entrySet()) {
+                String name = entry.getKey();
+                //do not overwrite explicitly defined parameters
+                if (!queryParams.containsKey(name)) {
+                    List<String> values = entry.getValue();
+                    if (values.size() == 1) {
+                        String value = values.get(0);
+                        String sanitized = null != value && 2 < value.length() ? value.trim() : "";
+                        if (sanitized.contains("#{") || sanitized.contains("${")) {
+                            FacesContext context = FacesContext.getCurrentInstance();
+                            value = context.getApplication().evaluateExpressionGet(context, value, String.class);
+                            queryParams.put(name, Arrays.asList(value));
+                        } else {
+                            queryParams.put(name, values);
+                        }
+                    } else {
+                        queryParams.put(name, values);
+                    }
+                }
+            }
+        }
+        String toFlowDocumentId = navigationCase.getToFlowDocumentId();
+        if (toFlowDocumentId != null) {
+            List<String> flowDocumentIdValues = new ArrayList<>();
+            flowDocumentIdValues.add(toFlowDocumentId);
+            queryParams.put(FlowHandler.TO_FLOW_DOCUMENT_ID_REQUEST_PARAM_NAME, flowDocumentIdValues);
+            if (!FlowHandler.NULL_FLOW.equals(toFlowDocumentId)) {
+                List<String> flowIdValues = new ArrayList<>();
+                flowIdValues.add(navigationCase.getFromOutcome());
+                queryParams.put(FlowHandler.FLOW_ID_REQUEST_PARAM_NAME, flowIdValues);
+            }
+        }
+    }
+    
+    /**
+     * Generate bookmarkable URL for the <code>NavigationCase</code> with supplied 
+     * query parameters by a call to <code>ViewHandler::getBookmarkableURL</code> method.
+     * 
+     * @param context <code>FacesContext</code> instance. 
+     * @param navigationCase current <code>NavigationCase</code>.
+     * @param params query parameters to be added to the generated URL.
+     * @return generated bookmarkable URL with query parameters.
+     */
+    private String getBaseBookmarkableURL(FacesContext context, NavigationCase navigationCase, Map<String, List<String>> params) {
+        String href;
+        String toViewId = navigationCase.getToViewId(context);
+        boolean isIncludeViewParams = isIncludeViewParams() || navigationCase.isIncludeViewParams();
+
+        boolean clientWindowRenderingEnabled = false;
+        ClientWindow clientWindow = null;
+        try {
+            if (isDisableClientWindow()) {
+                clientWindow = context.getExternalContext().getClientWindow();
+                if (clientWindow != null) {
+                    clientWindowRenderingEnabled = clientWindow.isClientWindowRenderModeEnabled(context);
+                    if (clientWindowRenderingEnabled) {
+                        clientWindow.disableClientWindowRenderMode(context);
+                    }
+                }
+            }
+            ViewHandler viewHandler = context.getApplication().getViewHandler();
+            href = viewHandler.getBookmarkableURL(context, toViewId, params, isIncludeViewParams);
+        } finally {
+            if (clientWindowRenderingEnabled && clientWindow != null) {
+                clientWindow.enableClientWindowRenderMode(context);
+            }
+        }
+        return href;
+    }
+    
+    /**
+     * Generate URI-encoded path from supplied path parameters.
+     * 
+     * @param pathParams path parameters to extract values from.
+     * @return URI-encoded path value.
+     */
+    private String generatePathFromParameters(Map<Integer, List<String>> pathParams) {
+        List<List<String>> params = pathParams.entrySet().stream()
+                .sorted(Comparator.comparing(Map.Entry::getKey))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+        String path = params.stream()
+                .flatMap(List::stream)
+                .filter(g -> g != null && !"".equals(g))
+                .map(g -> encodeURI(g))
+                .collect(Collectors.joining("/"));
+        return "".equals(path) ? "" : "/" + path;
+    }
+    
+    // Helpers
+    /**
+     * Collect all attributes of the component that should be rendered.
+     * 
+     * @return unmodifiable map that contains all attributes of the component
+     * that should be rendered.
+     */
+    private static Map<String, String> getLinkAttributes() {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("accesskey", "accesskey");
+        attrs.put("charset", "charset");
+        attrs.put("coords", "coords");
+        attrs.put("dir", "dir");
+        attrs.put("hreflang", "hreflang");
+        attrs.put("lang", "lang");
+        attrs.put("onblur", "blur");
+        attrs.put("onclick", "click");
+        attrs.put("ondblclick", "dblclick");
+        attrs.put("onfocus", "focus");
+        attrs.put("onkeydown", "keydown");
+        attrs.put("onkeypress", "keypress");
+        attrs.put("onkeyup", "keyup");
+        attrs.put("onmousedown", "mousedown");
+        attrs.put("onmousemove", "mousemove");
+        attrs.put("onmouseout", "mouseout");
+        attrs.put("onmouseover", "mouseover");
+        attrs.put("onmouseup", "mouseup");
+        attrs.put("rel", "rel");
+        attrs.put("rev", "rev");
+        attrs.put("role", "role");
+        attrs.put("shape", "shape");
+        attrs.put("style", "style");
+        attrs.put("tabindex", "tabindex");
+        attrs.put("target", "target");
+        attrs.put("title", "title");
+        attrs.put("type", "type");
+        return Collections.unmodifiableMap(attrs);
+    }
+
+    /**
+     * Functional interface that declares <code>Consumer</code> method that 
+     * throws <code>Exception</code>.
+     * 
+     * @param <T> input type.
+     * @param <E> exception type.
+     */
+    @FunctionalInterface
+    public interface ConsumerChecked<T, E extends Exception> {
+        void accept(T t) throws E;
+    }
+
+    /**
+     * Rethrow a checked <code>Exception</code> by wrapping it in a 
+     * <code>RuntimeException</code>.
+     * 
+     * @param <T> input type.
+     * @param <E> exception type.
+     * @param consumerChecked consumerChecked instance.
+     * @return wrapped <code>Consumer</code> functional interface.
+     */
+    public static <T, E extends Exception> Consumer<T> consumerRethrower(ConsumerChecked<T, E> consumerChecked) {
+        return i -> {
+            try {
+                consumerChecked.accept(i);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        };
+    }
+
+    /**
+     * Check if a component is an active path parameter.
+     * 
+     * @param component UIComponent to check.
+     * @return <code>true</code> if parameter is an active path parameter and
+     * <code>false</code> otherwise.
+     */
+    public static boolean isActivePathParameter(UIComponent component) {
+        return component instanceof PathParam && !((PathParam) component).isDisable() && !((PathParam) component).getBasic(); // rendered not taken into account
+    }
+
+    /**
+     * Adds a <code>FacesMessage</code> with severity <code>SEVERITY_WARN</code>
+     * to the <code>FacesContext</code>.
+     * 
+     * @param context <code>FacesContext</code> to add message to.
+     * @param message <code>FacesMessage</code> to be added.
+     */
+    public static void addFacesWarnMessage(FacesContext context, String message) {
+        FacesMessage msg = new FacesMessage(message);
+        msg.setSeverity(FacesMessage.SEVERITY_WARN);
+        context.addMessage(null, msg);
+    }
+    
+}

--- a/src/main/java/org/omnifaces/component/output/PathParam.java
+++ b/src/main/java/org/omnifaces/component/output/PathParam.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.component.output;
+
+import javax.faces.component.FacesComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+
+/**
+ * The <code>&lt;o:pathParam&gt;</code> is a component that extends the OmniFaces {@link Param} to support 
+ * <code>MultiViews</code> feature of {@link org.omnifaces.facesviews.FacesViews} by rendering the supplied parameters of such components 
+ * as <code>&lt;o:link&gt;</code> and <code>&lt;o:button&gt;</code> as path parameters and not as query parameters 
+ * as otherwise will be produced by <code>&lt;o:param&gt;</code> and <code>&lt;f:param&gt;</code>. 
+ * The component supports {@link Converter} to convert the supplied value to string, if necessary.
+ * <p>
+ * The component has built-in support for a {@link Converter} by usual means via the <code>converter</code> 
+ * attribute of the tag, or the nested <code>&lt;f:converter&gt;</code> tag, or just automatically if a converter is 
+ * already registered for the target class via <code>@FacesConverter(forClass)</code>.
+ * <p>
+ * It can be also be used in a same way as <code>&lt;f:param&gt;</code> if it is either declared as a child of 
+ * standard components like <code>&lt;h:link&gt;</code> and <code>&lt;h:button&gt;</code> or when it is a child of 
+ * <code>&lt;o:link&gt;</code> and <code>&lt;o:button&gt;</code> and its <code>basic</code> attribute is set to true.
+ * <p>
+ * This component doesn't support returning encoded output of children as parameter value in case no value is present and 
+ * this feature is provided by {@link Param} component.
+ * <p>
+ * The component specifies two additional non-required attributes to the ones defined in <code>&lt;o:param&gt;</code>
+ * to fine-tune rendering of path parameters:
+ * <ul>
+ * <li>
+ * <code>basic</code>, non-required attribute that defines whether the component must be rendered as path parameter (false) 
+ * or query parameter (true), default value - false.
+ * </li>
+ * <li>
+ * <code>index</code>, non-required attribute that defines relative rendering location of the component.
+ * </li>
+ * </ul>
+ * <p>
+ * Rendering of this component is done by evaluating the <code>value</code> attribute of the component if it 
+ * must be rendered as a path parameter and traditionally by evaluating the <code>name</code> and <code>value</code> 
+ * attributes of the component if it must be rendered as a query parameter.
+ * <p>
+ * Rendering location can be specified explicitly by defining <code>index</code> attribute and components with equal 
+ * value of this attribute will be rendered in the order they were defined. If this attribute is left unspecified then 
+ * all of the components with unspecified <code>index</code> will be rendered in the order they were defined and by 
+ * the mechanism specified by <code>location</code> attribute of <code>&lt;o:link&gt;</code> and 
+ * <code>&lt;o:button&gt;</code>, or after all of the other parameters with specified indices by default. 
+ * Location only specifies relative context of rendering, i.e.: two parameters with indices "1" and "3" will be rendered 
+ * in exactly the same way as two parameters with indices "5" and "7" if no other parameters are present. Negative
+ * values are also supported.
+ * <p>
+ * Example of its usage follows. The first parameter must be rendered as a path parameter at a relative location, "1", 
+ * the second parameter will be rendered after all other path parameters (default), the third parameter will be rendered 
+ * as a query parameter with the specified name and the fourth parameter won't be rendered at all, as no name was set.
+ * <pre>
+ * &lt;o:link value="Link" outcome="multiview-supported-path"&gt;
+ *     &lt;o:pathParam&gt; value="first" index="1"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="no-index"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; name="basic" value="basic" basic="true"&lt;/o:pathParam&gt;
+ *     &lt;o:pathParam&gt; value="not-rendered" basic="true"&lt;/o:pathParam&gt;
+ * &lt;/o:link&gt;
+ * </pre>
+ * The code above will be rendered, assuming default settings, as: 
+ * <code>&lt;a id="..." name="..." href="/context-path/multiview-supported-path/first/no-index?basic=basic"&gt;Link&lt;/a&gt;</code>
+ * 
+ * @author Sergey Kuntsel
+ * @since 3.0
+ * @see Link
+ * @see Button
+ */
+@FacesComponent(PathParam.COMPONENT_TYPE)
+public class PathParam extends Param {
+
+    // Constants
+    public static final String COMPONENT_TYPE = "org.omnifaces.component.output.PathParam";
+
+    // Properties
+    private enum PropertyKeys {
+        basic, // treat path parameter as standard parameter
+        index; // index to render path parameter at
+    }
+
+    /**
+     * Return basic property that defines whether the component must be rendered as path parameter (false) 
+     * or query parameter (true), default value - false.
+     * 
+     * @return basic property.
+     */
+    public Boolean getBasic() { return (Boolean)getStateHelper().eval(PropertyKeys.basic, Boolean.FALSE); }
+    
+    /**
+     * Set basic property that defines whether the component must be rendered as path parameter (false) 
+     * or query parameter (true), default value - false.
+     * 
+     * @param basic property value to set.
+     */
+    public void setBasic(Boolean basic) { getStateHelper().put(PropertyKeys.basic, basic); }
+
+    /**
+     * Return index property that defines relative rendering location of the component.
+     * 
+     * @return index property.
+     */
+    public Integer getIndex() { return (Integer)getStateHelper().eval(PropertyKeys.index); }
+
+    /**
+     * Set index property that defines relative rendering location of the component.
+     * 
+     * @param index property value to set.
+     */
+    public void setIndex(Integer index) { getStateHelper().put(PropertyKeys.index, index); }
+
+    // Actions
+    @Override
+    public Object getValue() {
+        FacesContext context = getFacesContext();
+        Converter converter = getConverter();
+        Object value = getLocalValue();
+
+        if (converter == null && value != null) {
+            converter = context.getApplication().createConverter(value.getClass());
+        }
+
+        if (converter != null) {
+            return converter.getAsString(context, this, value);
+        } else {
+            return value;
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/omnifaces-ui.taglib.xml
+++ b/src/main/resources/META-INF/omnifaces-ui.taglib.xml
@@ -5451,4 +5451,1372 @@ String name2 = Faces.getRequestParameter("name2"); // value2
 			<type>boolean</type>
 		</attribute>
 	</tag>
+
+    <tag>
+        <description>
+            <![CDATA[
+                <strong>PathParam</code> is a component that extends the OmniFaces <code>Param</code> to support 
+                <code>MultiViews</code> feature of <code>FacesViews</code> by rendering the supplied parameters of such components 
+                as <code>&lt;o:link&gt;</code> and <code>&lt;o:button&gt;</code> as path parameters and not as query parameters 
+                as otherwise will be produced by <code>&lt;o:param&gt;</code> and <code>&lt;f:param&gt;</code>. 
+                The component supports <code>Converter}</code> to convert the supplied value to string, if necessary.
+                <p>
+                The component has built-in support for a <code>Converter</code> by usual means via the <code>converter</code> 
+                attribute of the tag, or the nested <code>&lt;f:converter&gt;</code> tag, or just automatically if a converter is 
+                already registered for the target class via <code>@FacesConverter(forClass)</code>.
+                <p>
+                It can be also be used in a same way as <code>&lt;f:param&gt;</code> if it is either declared as a child of 
+                standard components like <code>&lt;h:link&gt;</code> and <code>&lt;h:button&gt;</code> or when it is a child of 
+                <code>&lt;o:link&gt;</code> and <code>&lt;o:button&gt;</code> and its <code>basic</code> attribute is set to true.
+                <p>
+                This component doesn't support returning encoded output of children as parameter value in case no value is present and 
+                this feature is provided by <code>Param</code> component.
+                <p>
+                The component specifies two additional non-required attributes to the ones defined in <code>&lt;o:param&gt;</code>
+                to fine-tune rendering of path parameters:
+                <ul>
+                <li>
+                <code>basic</code>, non-required attribute that defines whether the component must be rendered as path parameter (false) 
+                or query parameter (true), default value - false.
+                </li>
+                <li>
+                <code>index</code>, non-required attribute that defines relative rendering location of the component.
+                </li>
+                </ul>
+                <p>
+                Rendering of this component is done by evaluating the <code>value</code> attribute of the component if it 
+                must be rendered as a path parameter and traditionally by evaluating the <code>name</code> and <code>value</code> 
+                attributes of the component if it must be rendered as a query parameter.
+                <p>
+                Rendering location can be specified explicitly by defining <code>index</code> attribute and components with equal 
+                value of this attribute will be rendered in the order they were defined. If this attribute is left unspecified then 
+                all of the components with unspecified <code>index</code> will be rendered in the order they were defined and by 
+                the mechanism specified by <code>location</code> attribute of <code>&lt;o:link&gt;</code> and 
+                <code>&lt;o:button&gt;</code>, or after all of the other parameters with specified indices by default. 
+                Location only specifies relative context of rendering, i.e.: two parameters with indices "1" and "3" will be rendered 
+                in exactly the same way as two parameters with indices "5" and "7" if no other parameters are present. Negative
+                values are also supported.
+                <p>
+                Example of its usage follows. The first parameter must be rendered as a path parameter at a relative location, "1", 
+                the second parameter will be rendered after all other path parameters (default), the third parameter will be rendered 
+                as a query parameter with the specified name and the fourth parameter won't be rendered at all, as no name was set.
+                <pre>
+&lt;o:link value="Link" outcome="multiview-supported-path"&gt;
+    &lt;o:pathParam&gt; value="first" index="1"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="no-index"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="basic" value="basic" basic="true"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="not-rendered" basic="true"&lt;/o:pathParam&gt;
+&lt;/h:outputFormat&gt;
+                </pre>
+                The code above will be rendered, assuming default settings, as: 
+                <code>&lt;a id="..." name="..." href="/context-path/multiview-supported-path/first/no-index?basic=basic"&gt;Link&lt;/a&gt;</code>
+            ]]>
+        </description>
+        <tag-name>pathParam</tag-name>
+        <component>
+            <component-type>org.omnifaces.component.output.PathParam</component-type>
+        </component>
+        
+        <attribute>
+            <description>
+                <![CDATA[
+                    The component identifier for this component. This value must be unique within the closest parent
+                    component that is a naming container.
+                ]]>
+            </description>
+            <name>id</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    The <code>ValueExpression</code> linking this component to a property in a backing bean.
+                ]]>
+            </description>
+            <name>binding</name>
+            <required>false</required>
+            <type>javax.faces.component.UIComponent</type>
+        </attribute>
+
+        <attribute>
+            <description>
+                <![CDATA[
+                    Converter instance registered with this component.
+                ]]>
+            </description>
+            <name>converter</name>
+            <required>false</required>
+            <type>javax.faces.convert.Converter</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag enabling or disabling the inclusion of the parameter.
+                ]]>
+            </description>
+            <name>disable</name>
+            <required>false</required>
+            <type>boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Name of the parameter to be created.
+                ]]>
+            </description>
+            <name>name</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Value of the parameter to be set.
+                ]]>
+            </description>
+            <name>value</name>
+            <required>false</required>
+            <type>java.lang.Object</type>
+        </attribute>
+        
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag to determine whether the component should be rendered as path parameter or as 
+                    standard query parameter. Default value of the attribute is false.
+                ]]>
+            </description>
+            <name>basic</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Relative rendering position of the component.
+                ]]>
+            </description>
+            <name>index</name>
+            <required>false</required>
+            <type>java.lang.Integer</type>
+        </attribute>
+    </tag>
+
+    <tag>
+        <description>
+            <![CDATA[
+                <strong>Link</strong> is a component that extends the standard <code>HtmlOutcomeTargetLink</code> component to support 
+                <code>MultiViews</code> feature of <code>FacesView</code> by rendering the supplied <code>&lt;o:pathParam&gt;</code>
+                parameters as path parameters and not as query parameters as otherwise will be produced by standard <code>&lt;o:param&gt;</code> and 
+                <code>&lt;f:param&gt;</code>, or if <code>&lt;o:pathParam&gt;</code> tags are nested in a standard <code>&lt;h:link&gt;</code>.
+                <p>
+                To achieve this goal <code>&lt;o:pathParam&gt;</code> tags must be specified as children of <code>&lt;o:link&gt;</code>. See <code>PathParam</code>
+                for an overview of configuration of path parameters. Any <code>&lt;o:pathParam&gt;</code> tag will be rendered as a part of the URL path of 
+                this component, like <i>/path-parameter-evaluated-value</i>, if the following conditions are met:
+                <ol>
+                <li>
+                <code>outcome</code> attribute of the current <code>&lt;o:link&gt;</code> component specifies a valid MultiView page, 
+                see <code>FacesViews</code> for a proper way of configuring <code>MultiViews</code> feature.
+                </li>
+                <li>
+                <code>basic</code> attribute of the current component must evaluate to false (or left as default).
+                </li>
+                <li>
+                <code>basic</code> attribute of <code>&lt;o:pathParam&gt;</code> tag must evaluate to false (or left as default).
+                </li>
+                </ol>
+                <p>
+                The ordering of path parameters will be defined according to the <code>index</code> attribute of <code>&lt;o:pathParam&gt;</code> tags. 
+                In case of collisions the tags with equal indices, either specified and unspecified, will be rendered in the order they were defined. 
+                The location of paths with unspecified indices will be derived from <code>location</code> attribute of this component, see description below. 
+                Location and indices only specify relative context of rendering, or before-after relation. Negative indices are also supported.
+                <p>
+                This component also accepts standard parameters, <code>&lt;o:param&gt;</code> and <code>&lt;f:param&gt;</code>, and will render
+                them as query parameters, as it has always traditionally been done by <code>UIOutcomeTarget</code> components like <code>&lt;h:link&gt;</code> and 
+                <code>&lt;h:button&gt;</code>. <code>&lt;o:pathParam&gt;</code> tags can also be rendered as query parameters if their <code>basic</code>
+                attributes evaluate to true. It can be helpful if an application has to decide upon way of rendering at runtime, by checking 
+                <code>#{someCondition}</code>.
+                <p>
+                The component specifies three additional non-required attributes to control and fine-tune the generated path from path parameters:
+                <ul>
+                <li>
+                <code>location</code>, non-required attribute that defines the location where <code>&lt;o:pathParam&gt;</code> tags with non-specified 
+                <code>index</code> attributes relative to the ones with the specified <code>index</code> attribute will be rendered: after all path 
+                parameters for attribute value "end", before all path parameters for attribute value "beginning" or at a specified location for attribute 
+                integer value, i.e. for components where <code>Integer.valueOf(getLocation())</code> doesn't throw <code>NumberFormatException</code>. 
+                Default value of this attribute is "end". All other values will be treated as "end" as well.
+                </li>
+                <li>
+                <code>force</code>, non-required attribute that defines behaviour when <code>outcome</code> attribute doesn't specify a valid MultiView page:
+                if the attribute value is true then if any <code>&lt;o:pathParam&gt;</code> with <code>basic</code> attribute evaluating to false are present 
+                the component will be rendered as disabled and generate a <code>FacesMessage</code> that the outcome is not a valid MultiView page, if the 
+                attribute value is false, any <code>&lt;o:pathParam&gt;</code> tag will be treated as simple <code>&lt;o:param&gt;</code> thus producing 
+                query parameters for all parameters with a specified non-empty name. Default value is true.
+                </li>
+                <li>
+                <code>basic</code>, non-required attribute that is used to turn off dealing with <code>&lt;o:pathParam&gt;</code> tags as path parameters.
+                If this property evaluates to true, all present <code>&lt;o:pathParam&gt;</code> tags will be treated as <code>&lt;o:param&gt;</code> tags,
+                thus overriding all preset behaviour of the component and its children. If this property evaluates to false, the rendering will proceed
+                in a standard fashion, described above. This attribute is helpful when an application needs to turn off defined behaviour basing on
+                some condition. Default value is false.
+                </li>
+                </ul>
+                <p>
+                There are two additional properties to the ones defined in <code>&lt;h:link&gt;</code> to account for extra features: 
+                <ul>
+                <li>
+                <code>fragment</code>, non-required attribute that attaches hash-separated fragment at the end of the URL, if present and not empty.
+                </li>
+                <li>
+                <code>escape</code>, non-required attribute that defines whether or not to escape the value of this component. Default value is true.
+                Beware of potential XSS attack holes when redisplaying user-controlled input with <code>escape="false"</code>.
+                </li>
+                </ul>
+                <p>
+                This component is useful when application must provide links to the MultiView-configured pages with parameters rendered as part of the 
+                path and not a part of the query string, as it is traditionally done. The sending page defines a <code>&lt;o:link&gt;</code> with 
+                <code>&lt;o:pathParam&gt;</code>s, thus generating URL with path parameters, and the receiving page consumes these path parameters in 
+                CDI beans by means of <code>Param</code> with a specified <code>pathIndex</code> property.
+                <p>
+                There are some options, described above, for tuning the generated URL of this component in various circumstances. This component 
+                can also be used to generate standard links for non-MultiView pages as well as links for MultiView pages with standard appearance.
+                <p>
+                The component provides predefined CSS classes to support defining styles for all used components of this type in ones place. Additionally,
+                user-defined CSS classes can be added via the traditional <code>styleClass</code> attribute. All active links, i.e. those links that are not disabled, 
+                have a proper outcome and satisfy the requirements for the <code>MultiViews</code> mentioned above, will be rendered as <code>a</code> HTML elements.
+                All disabled links, i.e. the links that don't satisfy any of the requirement for active links, will be rendered as <code>span</code> HTML elements.
+                As nesting children is allowed for the link component and it is the application responsibility to create right HTML structure for proper
+                appearance of the link. Also note that both the value of the component and its children, if present, will be rendered to HTML output, so 
+                this must be taken into account when developing applications. It is recommended either to use the value and don't have any rendered children 
+                or leave the value blank and have content by rendering children, though this approach isn't enforced by the component.
+                These classes are:
+                <ul>
+                <li>"of-link" for all generated <code>a</code> HTML elements reflecting active links.</li>
+                <li>"of-link-disabled" for all generated <code>span</code> HTML elements reflecting disabled links.</li>
+                </ul>
+                <p>
+                Basic usage examples follow. They assume that <code>FacesViews</code> is turned on and <code>MultiViews</code>
+                configuration is present for paths "/users/*", "/path/*" and "/blog/*":
+                <pre>
+&lt;context-param&gt;
+    &lt;param-name&gt;org.omnifaces.FACES_VIEWS_SCAN_PATHS&lt;/param-name&gt;
+    &lt;param-value&gt;/*.xhtml, /user/*, /path/*, /blog/*&lt;/param-value&gt;
+&lt;/context-param&gt;
+                </pre>
+                For additional information on how to configure FacesViews and use the MutiViews feature see <code>FacesViews</code>.
+                <p>
+                In the following example the component generates a link to a view user detail page by employing implicit <code>@FacesConverter(forClass)</code>
+                converter.
+                <pre>
+&lt;o:link value="User details" outcome="user"&gt;
+    &lt;o:pathParam&gt; value="#{bean.user}" /&gt;
+&lt;/o:link&gt;
+                </pre>
+                with
+                <pre>
+@FacesConverter(forClass = User.class) public class UserConverter implements Converter {
+    public Object getAsObject(FacesContext context, UIComponent component, String value) {
+        if (value == null) { return null; } return new User(value);
+    }
+    public String getAsString(FacesContext context, UIComponent component, Object value) {
+        if(value == null) { return ""; }
+        if(value instanceof User) { User user = (User)value; return user.getUsername(); }
+        throw new ConverterException(value + " not a User");
+    }
+}
+@Named @RequestScoped public class Bean { private User user; ... }
+public class User { private String username; ... }
+                </pre>
+                The generated URL could look like <code>/context-path/user/username</code>.
+                <p>
+                The following link shows a way of tuning the rendering of path parameters.
+                <pre>
+&lt;o:link value="Link" outcome="path" location="beginning"&gt;
+    &lt;o:pathParam&gt; value="first" index="1"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="no-index"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="basic" value="basic" basic="true"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="third" index="3"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="no-index-second" disable="#{someCondition}"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="#{bean.name}" converter="#{bean}" index="2"&lt;/o:pathParam&gt;
+&lt;/o:link&gt;
+                </pre>
+                The generated URL could look like <code>/context-path/path/no-index/no-index-second/first/bean-name/third?basic=basic</code>.
+                <p>
+                Note that if the outcome of the link above pointed at a standard view id, say, <code>index</code> then the construct will
+                be rendered as a disabled link (impossible to render path parameters at a standard outcome). Still, configuring
+                &lt;o:link ... force="false" /&gt; will render an active link with all of the parameter rendered as query parameters (for 
+                parameters with non-empty name). Also note that standard parameters are perfectly legal:
+                <pre>
+&lt;o:link ...&gt;
+    &lt;o:pathParam&gt; ...&lt;/o:pathParam&gt;
+    &lt;o:param&gt; name="omniparam" value="omniparam"&lt;/o:param&gt;
+    &lt;f:param&gt; name="fparam" value="fparam"&lt;/f:param&gt;
+&lt;/o:link&gt;
+                </pre>
+                Another option to turn off rendering of path parameters altogether is to set a condition for the <code>basic</code> attribute:
+                <pre>
+&lt;o:link value="Link" outcome="path" basic="#{someCondition}"&gt;
+    &lt;o:pathParam&gt; name="first" value="first"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="second" value="second"&lt;/o:pathParam&gt;
+&lt;/o:link&gt;
+                </pre>
+                If <code>#{someCondition}</code> evaluates to false, the URL will be rendered as <code>/context-path/path/first/second</code>,
+                and if it evaluates to true, the URL will be rendered as <code>/context-path/path?first=first&second=second</code>.
+                <p>
+                The significant benefit of using the <code>&lt;o:link&gt;</code> component is its ability to integrate with JSF infrastructure.
+                The <code>outcome</code> attribute will be internally checked by a <code>NavigationHandler</code> and <code>ViewHandler</code> 
+                and in case of negative result the component will be rendered as disabled and a message will be printed. On the one hand this 
+                will reduce the number of hand-written errors and on the other hand will incorporate all user-created artifacts, like custom
+                <code>ViewHandlerWrapper</code> classes with overridden <code>getActionURL(...)</code> methods to reflect and generate valid 
+                and up-to-date URLs for output components.
+                <p>
+                The following component, for example, will be rendered as disabled: <code>&lt;o:link outcome="non-existing-path" .../&gt;</code>.
+                <p>
+                The following component will render a link with a prefix, if <code>getActionURL(...)</code> were overridden accordingly to prefix 
+                all paths of a special subset of views to "/special": <code>&lt;o:link outcome="special-path-for-view-handler" .../&gt;</code>. 
+                The generated URL could look like <code>/context-path/special/special-path-for-view-handler/...</code>.
+                <p>
+                The last example renders URLs basing on available information. For example, we can have a mapping on "/blog" with year, month and 
+                day specified. The following link could be used to point at a valid blog post overview:
+                <pre>
+&lt;o:link value="Blog" outcome="blog"&gt;
+    &lt;o:pathParam&gt; name="year" value="#{userSettings.year}"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="month" value="#{userSettings.month}"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="day" value="#{userSettings.day}"&lt;/o:pathParam&gt;
+&lt;/o:link&gt;
+                </pre>
+                Of course, some additional logic must be incorporated to check parameters, but the construct above could be used to render links
+                with URLs of type <code>/context-path/blog/2017</code>, <code>/context-path/blog/2017/october</code> and 
+                <code>/context-path/blog/2017/october/1</code>, which could be rather fruitful under some circumstances.
+            ]]>
+        </description>
+        <tag-name>link</tag-name>
+        <component>
+            <component-type>org.omnifaces.component.output.Link</component-type>
+        </component>
+
+        <attribute>
+            <description>
+                <![CDATA[
+                    The component identifier for this component. This value must be unique within the closest parent
+                    component that is a naming container.
+                ]]>
+            </description>
+            <name>id</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    The <code>ValueExpression</code> linking this component to a property in a backing bean.
+                ]]>
+            </description>
+            <name>binding</name>
+            <required>false</required>
+            <type>javax.faces.component.UIComponent</type>
+        </attribute>
+
+        <attribute>
+            <description>
+                <![CDATA[
+                    Converter instance registered with this component.
+                ]]>
+            </description>
+            <name>converter</name>
+            <required>false</required>
+            <type>javax.faces.convert.Converter</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that disables appending the <code>ClientWindow</code> on the rendering of this element. Default value is false.
+                ]]>
+            </description>
+            <name>disableClientWindow</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that disables the component. Default value is false.
+                ]]>
+            </description>
+            <name>disabled</name>
+            <required>false</required>
+            <type>boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that indicates whether to include page view parameters in the target URI. Default value is false.
+                ]]>
+            </description>
+            <name>includeViewParams</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Outcome that is used to resolve a navigation case.
+                ]]>
+            </description>
+            <name>outcome</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that indicates whether this component should be rendered or not. Default value is true.
+                ]]>
+            </description>
+            <name>rendered</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Value of the component to be set.
+                ]]>
+            </description>
+            <name>value</name>
+            <required>false</required>
+            <type>java.lang.Object</type>
+        </attribute>
+        
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag to determine whether all nested <code>PathParam</code> tags will be treated as <code>UIParameter</code> tags or not.
+                    regardlesss of their settings. If the attribute evaluates to true, all path parameters will be rendered as query parameters, 
+                    thus effectively disabling path parameter behaviour basing on some condition. If it evaluates to false, standard rendering
+                    logic will be applied as instructed by other attributes of this component and nested path parameters. This attribute takes 
+                    precedence over the setting specified by the <code>force</code> attribute. Default value is false.
+                ]]>
+            </description>
+            <name>basic</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that indicates whether the value of this component must be escaped or not. For non-escaped components beware of potential XSS attack holes 
+                    when redisplaying user-controlled input. Default value is true.
+                ]]>
+            </description>
+            <name>escape</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag to determine the behaviour when <code>PathParam</code> tags were defined for an outcome representing a standard, 
+                    non-MultiView page. If this attribute evaluates to true nesting any <code>PathParam</code> tag within the component referencing 
+                    a standard outcome will cause the link to be rendered as disabled and will generate a warning message. If it evaluates to false, 
+                    all nested <code>PathParam</code> tags will be treated as <code>UIParameter</code> tags and will effectively be rendered as
+                    query parameters in the order they were declared. Default value is true.
+                ]]>
+            </description>
+            <name>force</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client element id of the target page where the page must be scrolled to.
+                ]]>
+            </description>
+            <name>fragment</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Location to render nested path parameters with unspecified index. Valid values are: "beginning" (at the beginning of the path), 
+                    "end" (at the end of the path), or any Integer value (at the specified index of the path). Any other strings and failure to
+                    parse and integer from the supplied string is the same as specifying "end" value of this attribute. Default value is "end".
+                ]]>
+            </description>
+            <description><![CDATA[Location]]></description>
+            <name>location</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+
+        <attribute>
+            <description>
+                <![CDATA[
+                    Access key that, when pressed, transfers focus to this component.
+                ]]>
+            </description>
+            <name>accesskey</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Character encoding of the resource designated by this component.
+                ]]>
+            </description>
+            <name>charset</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Position and shape of the hot spot on the screen for usage in client-side image maps.
+                ]]>
+            </description>
+            <name>coords</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Direction indication for text that does not inherit directionality. Valid values are "LTR" (left-to-right) and "RTL" (right-to-left), both case-sensitive.
+                ]]>
+            </description>
+            <name>dir</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Language code of the resource designated by this component.
+                ]]>
+            </description>
+            <name>hreflang</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Code describing the language used in the generated markup for this component.
+                ]]>
+            </description>
+            <name>lang</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Relationship from the current document to the anchor specified by this component. The value of this attribute is a space-separated list of link types.
+                ]]>
+            </description>
+            <name>rel</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Reverse link from the anchor specified by this component to the current document. The value of this attribute is a space-separated list of link types.
+                ]]>
+            </description>
+            <name>rev</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Per the WAI-ARIA spec and its relationship to HTML5 (Section title ARIA Role Attriubute), every HTML element may have a "role" attribute whose value must be passed through 
+                    unmodified on the element on which it is declared in the final rendered markup. The attribute, if specified, must have a value that is a string literal that is, or an EL 
+                    Expression that evaluates to, a set of space-separated tokens representing the various WAI-ARIA roles that the element belongs to. It is the page author's responsibility 
+                    to ensure that the user agent is capable of correctly interpreting the value of this attribute.
+                ]]>
+            </description>
+            <name>role</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Shape of the hot spot on the screen for usage in client-side image maps. Valid values are: default (entire region), rect (rectangular region), circle (circular region) and poly (polygonal region).
+                ]]>
+            </description>
+            <name>shape</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    CSS styles to be applied on the generated anchor element.
+                ]]>
+            </description>
+            <name>style</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Space-separated list of CSS style classes to be applied on the generated anchor element.
+                ]]>
+            </description>
+            <name>styleClass</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Position of this component in the tabbing order for the current document. This value must be an integer between 0 and 32767.
+                ]]>
+            </description>
+            <name>tabindex</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Name of a frame where the resource of this component will be displayed.
+                ]]>
+            </description>
+            <name>target</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Advisory tooltip information for this component.
+                ]]>
+            </description>
+            <name>title</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Content type of the resource referenced by this component.
+                ]]>
+            </description>
+            <name>type</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link loses focus.
+                ]]>
+            </description>
+            <name>onblur</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link is clicked.
+                ]]>
+            </description>
+            <name>onclick</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link is double clicked.
+                ]]>
+            </description>
+            <name>ondblclick</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link receives focus.
+                ]]>
+            </description>
+            <name>onfocus</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a key is pressed down over the link.
+                ]]>
+            </description>
+            <name>onkeydown</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a key is pressed and released over the link.
+                ]]>
+            </description>
+            <name>onkeypress</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a key is released over the link.
+                ]]>
+            </description>
+            <name>onkeyup</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is pressed down over the link.
+                ]]>
+            </description>
+            <name>onmousedown</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is moved within the link.
+                ]]>
+            </description>
+            <name>onmousemove</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is moved away from the link.
+                ]]>
+            </description>
+            <name>onmouseout</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is moved onto the link.
+                ]]>
+            </description>
+            <name>onmouseover</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is released over the link.
+                ]]>
+            </description>
+            <name>onmouseup</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+    </tag>
+
+    <tag>
+        <description>
+            <![CDATA[
+                <strong>Button</strong> is a component that extends the standard <code>HtmlOutcomeTargetButton</code> component to support 
+                <code>MultiViews</code> feature of <code>FacesViews</code> by rendering the supplied <code>&lt;o:pathParam&gt;</code>
+                parameters as path parameters and not as query parameters as otherwise will be produced by standard <code>&lt;o:param&gt;</code> and 
+                <code>&lt;f:param&gt;</code>, or if <code>&lt;o:pathParam&gt;</code> tags are nested in a standard <code>&lt;h:button&gt;</code>.
+                <p>
+                To achieve this goal <code>&lt;o:pathParam&gt;</code> tags must be specified as children of <code>&lt;o:button&gt;</code>. See <code>PathParam</code>
+                for an overview of configuration of path parameters. Any <code>&lt;o:pathParam&gt;</code> tag will be rendered as a part of the URL path of 
+                this component, like <i>/path-parameter-evaluated-value</i>, if the following conditions are met:
+                <ol>
+                <li>
+                <code>outcome</code> attribute of the current <code>&lt;o:button&gt;</code> component specifies a valid MultiView page, 
+                see <code>FacesViews</code> for a proper way of configuring <code>MultiViews</code> feature.
+                </li>
+                <li>
+                <code>basic</code> attribute of the current component must evaluate to false (or left as default).
+                </li>
+                <li>
+                <code>basic</code> attribute of <code>&lt;o:pathParam&gt;</code> tag must evaluate to false (or left as default).
+                </li>
+                </ol>
+                <p>
+                The ordering of path parameters will be defined according to the <code>index</code> attribute of <code>&lt;o:pathParam&gt;</code> tags. 
+                In case of collisions the tags with equal indices, either specified and unspecified, will be rendered in the order they were defined. 
+                The location of paths with unspecified indices will be derived from <code>location</code> attribute of this component, see description below. 
+                Location and indices only specify relative context of rendering, or before-after relation. Negative indices are also supported.
+                <p>
+                This component also accepts standard parameters, <code>&lt;o:param&gt;</code> and <code>&lt;f:param&gt;</code>, and will render
+                them as query parameters, as it has always traditionally been done by <code>UIOutcomeTarget</code> components like <code>&lt;h:link&gt;</code> and 
+                <code>&lt;h:button&gt;</code>. <code>&lt;o:pathParam&gt;</code> tags can also be rendered as query parameters if their <code>basic</code>
+                attributes evaluate to true. It can be helpful if an application has to decide upon way of rendering at runtime, by checking 
+                <code>#{someCondition}</code>.
+                <p>
+                The component specifies three additional non-required attributes to control and fine-tune the generated path from path parameters:
+                <ul>
+                <li>
+                <code>location</code>, non-required attribute that defines the location where <code>&lt;o:pathParam&gt;</code> tags with non-specified 
+                <code>index</code> attributes relative to the ones with the specified <code>index</code> attribute will be rendered: after all path 
+                parameters for attribute value "end", before all path parameters for attribute value "beginning" or at a specified location for attribute 
+                integer value, i.e. for components where <code>Integer.valueOf(getLocation())</code> doesn't throw <code>NumberFormatException</code>. 
+                Default value of this attribute is "end". All other values will be treated as "end" as well.
+                </li>
+                <li>
+                <code>force</code>, non-required attribute that defines behaviour when <code>outcome</code> attribute doesn't specify a valid MultiView page:
+                if the attribute value is true then if any <code>&lt;o:pathParam&gt;</code> with <code>basic</code> attribute evaluating to false are present 
+                the component will be rendered as disabled and generate a <code>FacesMessage</code> that the outcome is not a valid MultiView page, if the 
+                attribute value is false, any <code>&lt;o:pathParam&gt;</code> tag will be treated as simple <code>&lt;o:param&gt;</code> thus producing 
+                query parameters for all parameters with a specified non-empty name. Default value is true.
+                </li>
+                <li>
+                <code>basic</code>, non-required attribute that is used to turn off dealing with <code>&lt;o:pathParam&gt;</code> tags as path parameters.
+                If this property evaluates to true, all present <code>&lt;o:pathParam&gt;</code> tags will be treated as <code>&lt;o:param&gt;</code> tags,
+                thus overriding all preset behaviour of the component and its children. If this property evaluates to false, the rendering will proceed
+                in a standard fashion, described above. This attribute is helpful when an application needs to turn off defined behaviour basing on
+                some condition. Default value is false.
+                </li>
+                </ul>
+                <p>
+                There are four additional properties to the ones defined in <code>&lt;h:button&gt;</code> to account for extra features: 
+                <ul>
+                <li>
+                <code>disabled</code>, non-required attribute that serves as a flag to disable the button. Default value is false.
+                </li>
+                <li>
+                <code>target</code>, non-required attribute that defines the name of a frame where the resource of this component will be displayed. Default value is "_self".
+                </li>
+                <li>
+                <code>fragment</code>, non-required attribute that attaches hash-separated fragment at the end of the URL, if present and not empty.
+                </li>
+                <li>
+                <code>escape</code>, non-required attribute that defines whether or not to escape the value of this component. Default value is true.
+                Beware of potential XSS attack holes when redisplaying user-controlled input with <code>escape="false"</code>.
+                </li>
+                </ul>
+                <p>
+                This component is useful when application must provide links to the MultiView-configured pages with parameters rendered as part of the 
+                path and not a part of the query string, as it is traditionally done. The sending page defines a <code>&lt;o:button&gt;</code> with 
+                <code>&lt;o:pathParam&gt;</code>s, thus generating URL with path parameters, and the receiving page consumes these path parameters in 
+                CDI beans by means of <code>Param</code> with a specified <code>pathIndex</code> property.
+                <p>
+                There are some options, described above, for tuning the generated URL of this component in various circumstances. This component 
+                can also be used to generate standard buttons for non-MultiView pages as well as buttons for MultiView pages with standard appearance.
+                <p>
+                The component provides a set of predefined CSS classes to support defining styles for all used components of this type in ones place. Additionally,
+                user-defined CSS classes can be added via the traditional <code>styleClass</code> attribute for the generated <code>button</code> HTML element and 
+                via the <code>image</code> attribute for the nested <code>span</code> HTML element, where the image has to be referenced via the CSS 
+                <code>background-image</code> property. In case the <code>image</code> attribute is absent, no image span will be rendered. Also note that it 
+                is the application responsibility to create right CSS classes for proper appearance of the button. Text of the button will be rendered in the 
+                <code>span</code> HTML element, next to the image element, if there is one. If no <code>image</code> attribute is specified, the text 
+                element will be rendered in any case, either with the supplied component value, or with the default text, if no <code>value</code> attribute was 
+                declared. The value of the component will be rendered as the button text. No declared children will be rendered to HTML output.
+                These classes are:
+                <ul>
+                <li>"of-button" for all generated active <code>button</code> HTML elements and "of-button-disabled" for all disabled ones.</li>
+                <li>"of-button-image" for all generated <code>span</code> HTML elements for referencing the image of the button.</li>
+                <li>"of-button-text" for all generated <code>span</code> HTML elements for holding the text of the button.</li>
+                </ul>
+                <p>
+                Basic usage examples follow. They assume that <code>FacesViews</code> is turned on and <code>MultiViews</code>
+                configuration is present for paths "/users/*", "/path/*" and "/blog/*":
+                <pre>
+&lt;context-param&gt;
+    &lt;param-name&gt;org.omnifaces.FACES_VIEWS_SCAN_PATHS&lt;/param-name&gt;
+    &lt;param-value&gt;/*.xhtml, /user/*, /path/*, /blog/*&lt;/param-value&gt;
+&lt;/context-param&gt;
+                </pre>
+                For additional information on how to configure FacesViews and use the MutiViews feature see <code>FacesViews</code>.
+                <p>
+                In the following example the component generates a button to a view user detail page by employing implicit <code>@FacesConverter(forClass)</code>
+                converter.
+                <pre>
+&lt;o:button value="User details" outcome="user"&gt;
+    &lt;o:pathParam&gt; value="#{bean.user}" /&gt;
+&lt;/o:button&gt;
+                </pre>
+                with
+                <pre>
+@FacesConverter(forClass = User.class) public class UserConverter implements Converter {
+    public Object getAsObject(FacesContext context, UIComponent component, String value) {
+        if (value == null) { return null; } return new User(value);
+    }
+    public String getAsString(FacesContext context, UIComponent component, Object value) {
+        if(value == null) { return ""; }
+        if(value instanceof User) { User user = (User)value; return user.getUsername(); }
+        throw new ConverterException(value + " not a User");
+    }
+}
+@Named @RequestScoped public class Bean { private User user; ... }
+public class User { private String username; ... }
+                </pre>
+                The generated URL referenced by the button could look like <code>/context-path/user/username</code>.
+                <p>
+                The following button shows a way of tuning the rendering of path parameters.
+                <pre>
+&lt;o:button value="Button" outcome="path" location="beginning"&gt;
+    &lt;o:pathParam&gt; value="first" index="1"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="no-index"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="basic" value="basic" basic="true"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="third" index="3"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="no-index-second" disable="#{someCondition}"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; value="#{bean.name}" converter="#{bean}" index="2"&lt;/o:pathParam&gt;
+&lt;/o:button&gt;
+                </pre>
+                The generated URL referenced by the button could look like <code>/context-path/path/no-index/no-index-second/first/bean-name/third?basic=basic</code>.
+                <p>
+                Note that if the outcome of the button above pointed at a standard view id, say, <code>index</code> then the construct will
+                be rendered as a disabled button (impossible to render path parameters at a standard outcome). Still, configuring
+                &lt;o:button ... force="false" /&gt; will render an active button with all of the parameter rendered as query parameters (for 
+                parameters with non-empty name). Also note that standard parameters are perfectly legal:
+                <pre>
+&lt;o:button ...&gt;
+    &lt;o:pathParam&gt; ...&lt;/o:pathParam&gt;
+    &lt;o:param&gt; name="omniparam" value="omniparam"&lt;/o:param&gt;
+    &lt;f:param&gt; name="fparam" value="fparam"&lt;/f:param&gt;
+&lt;/o:button&gt;
+                </pre>
+                Another option to turn off rendering of path parameters altogether is to set a condition for the <code>basic</code> attribute:
+                <pre>
+&lt;o:button value="Button" outcome="path" basic="#{someCondition}"&gt;
+    &lt;o:pathParam&gt; name="first" value="first"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="second" value="second"&lt;/o:pathParam&gt;
+&lt;/o:button&gt;
+                </pre>
+                If <code>#{someCondition}</code> evaluates to false, the URL referenced by the button will be rendered as <code>/context-path/path/first/second</code>,
+                and if it evaluates to true, the URL referenced by the button will be rendered as <code>/context-path/path?first=first&second=second</code>.
+                <p>
+                The significant benefit of using the <code>&lt;o:button&gt;</code> component is its ability to integrate with JSF infrastructure.
+                The <code>outcome</code> attribute will be internally checked by a <code>NavigationHandler</code> and <code>ViewHandler</code> 
+                and in case of negative result the component will be rendered as disabled and a message will be printed. On the one hand this 
+                will reduce the number of hand-written errors and on the other hand will incorporate all user-created artifacts, like custom
+                <code>ViewHandlerWrapper</code> classes with overridden <code>getActionURL(...)</code> methods to reflect and generate valid 
+                and up-to-date URLs for output components.
+                <p>
+                The following component, for example, will be rendered as disabled: <code>&lt;o:button outcome="non-existing-path" .../&gt;</code>.
+                <p>
+                The following component will render a button with a prefix, if <code>getActionURL(...)</code> were overridden accordingly to prefix 
+                all paths of a special subset of views to "/special": <code>&lt;o:button outcome="special-path-for-view-handler" .../&gt;</code>. 
+                The generated URL could look like <code>/context-path/special/special-path-for-view-handler/...</code>.
+                <p>
+                The last example renders URLs basing on available information. For example, we can have a mapping on "/blog" with year, month and 
+                day specified. The following button could be used to point at a valid blog post overview:
+                <pre>
+&lt;o:button value="Blog" outcome="blog"&gt;
+    &lt;o:pathParam&gt; name="year" value="#{userSettings.year}"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="month" value="#{userSettings.month}"&lt;/o:pathParam&gt;
+    &lt;o:pathParam&gt; name="day" value="#{userSettings.day}"&lt;/o:pathParam&gt;
+&lt;/o:button&gt;
+                </pre>
+                Of course, some additional logic must be incorporated to check parameters, but the construct above could be used to render buttons 
+                with referenced URLs of type <code>/context-path/blog/2017</code>, <code>/context-path/blog/2017/october</code> and 
+                <code>/context-path/blog/2017/october/1</code>, which could be rather fruitful under some circumstances.
+            ]]>
+        </description>
+        <tag-name>button</tag-name>
+        <component>
+            <component-type>org.omnifaces.component.output.Button</component-type>
+        </component>
+
+        <attribute>
+            <description>
+                <![CDATA[
+                    The component identifier for this component. This value must be unique within the closest parent
+                    component that is a naming container.
+                ]]>
+            </description>
+            <name>id</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    The <code>ValueExpression</code> linking this component to a property in a backing bean.
+                ]]>
+            </description>
+            <name>binding</name>
+            <required>false</required>
+            <type>javax.faces.component.UIComponent</type>
+        </attribute>
+
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that disables appending the <code>ClientWindow</code> on the rendering of this element. Default value is false.
+                ]]>
+            </description>
+            <name>disableClientWindow</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that indicates whether to include page view parameters in the target URI. Default value is false.
+                ]]>
+            </description>
+            <name>includeViewParams</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Outcome that is used to resolve a navigation case.
+                ]]>
+            </description>
+            <name>outcome</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that indicates whether this component should be rendered or not. Default value is true.
+                ]]>
+            </description>
+            <name>rendered</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Value of the component to be set.
+                ]]>
+            </description>
+            <name>value</name>
+            <required>false</required>
+            <type>java.lang.Object</type>
+        </attribute>
+        
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag to determine whether all nested <code>PathParam</code> tags will be treated as <code>UIParameter</code> tags or not.
+                    regardlesss of their settings. If the attribute evaluates to true, all path parameters will be rendered as query parameters, 
+                    thus effectively disabling path parameter behaviour basing on some condition. If it evaluates to false, standard rendering
+                    logic will be applied as instructed by other attributes of this component and nested path parameters. This attribute takes 
+                    precedence over the setting specified by the <code>force</code> attribute. Default value is false.
+                ]]>
+            </description>
+            <name>basic</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that disables the component. Default value is false.
+                ]]>
+            </description>
+            <name>disabled</name>
+            <required>false</required>
+            <type>boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag that indicates whether the value of this component must be escaped or not. For non-escaped components beware of potential XSS attack holes 
+                    when redisplaying user-controlled input. Default value is true.
+                ]]>
+            </description>
+            <name>escape</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Flag to determine the behaviour when <code>PathParam</code> tags were defined for an outcome representing a standard, 
+                    non-MultiView page. If this attribute evaluates to true nesting any <code>PathParam</code> tag within the component referencing 
+                    a standard outcome will cause the link to be rendered as disabled and will generate a warning message. If it evaluates to false, 
+                    all nested <code>PathParam</code> tags will be treated as <code>UIParameter</code> tags and will effectively be rendered as
+                    query parameters in the order they were declared. Default value is true.
+                ]]>
+            </description>
+            <name>force</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client element id of the target page where the page must be scrolled to.
+                ]]>
+            </description>
+            <name>fragment</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Location to render nested path parameters with unspecified index. Valid values are: "beginning" (at the beginning of the path), 
+                    "end" (at the end of the path), or any Integer value (at the specified index of the path). Any other strings and failure to
+                    parse and integer from the supplied string is the same as specifying "end" value of this attribute. Default value is "end".
+                ]]>
+            </description>
+            <description><![CDATA[Location]]></description>
+            <name>location</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Name of a frame where the resource of this component will be displayed. Default value is "_self".
+                ]]>
+            </description>
+            <name>target</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+
+        <attribute>
+            <description>
+                <![CDATA[
+                    Access key that, when pressed, transfers focus to this component.
+                ]]>
+            </description>
+            <name>accesskey</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Alternate textual description of this component.
+                ]]>
+            </description>
+            <name>alt</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Direction indication for text that does not inherit directionality. Valid values are "LTR" (left-to-right) and "RTL" (right-to-left), both case-sensitive.
+                ]]>
+            </description>
+            <name>dir</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Space-separated list of CSS style classes to be applied on the generated image nested in the button element. Note that image must be referenced through CSS.
+                ]]>
+            </description>
+            <name>image</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Code describing the language used in the generated markup for this component.
+                ]]>
+            </description>
+            <name>lang</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Per the WAI-ARIA spec and its relationship to HTML5 (Section title ARIA Role Attriubute), every HTML element may have a "role" attribute whose value must be passed through 
+                    unmodified on the element on which it is declared in the final rendered markup. The attribute, if specified, must have a value that is a string literal that is, or an EL 
+                    Expression that evaluates to, a set of space-separated tokens representing the various WAI-ARIA roles that the element belongs to. It is the page author's responsibility 
+                    to ensure that the user agent is capable of correctly interpreting the value of this attribute.
+                ]]>
+            </description>
+            <name>role</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    CSS styles to be applied on the generated anchor element.
+                ]]>
+            </description>
+            <name>style</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Space-separated list of CSS style classes to be applied on the generated button element.
+                ]]>
+            </description>
+            <name>styleClass</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Position of this component in the tabbing order for the current document. This value must be an integer between 0 and 32767.
+                ]]>
+            </description>
+            <name>tabindex</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Advisory tooltip information for this component.
+                ]]>
+            </description>
+            <name>title</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link loses focus.
+                ]]>
+            </description>
+            <name>onblur</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link is clicked.
+                ]]>
+            </description>
+            <name>onclick</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link is double clicked.
+                ]]>
+            </description>
+            <name>ondblclick</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when the link receives focus.
+                ]]>
+            </description>
+            <name>onfocus</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a key is pressed down over the link.
+                ]]>
+            </description>
+            <name>onkeydown</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a key is pressed and released over the link.
+                ]]>
+            </description>
+            <name>onkeypress</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a key is released over the link.
+                ]]>
+            </description>
+            <name>onkeyup</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is pressed down over the link.
+                ]]>
+            </description>
+            <name>onmousedown</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is moved within the link.
+                ]]>
+            </description>
+            <name>onmousemove</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is moved away from the link.
+                ]]>
+            </description>
+            <name>onmouseout</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is moved onto the link.
+                ]]>
+            </description>
+            <name>onmouseover</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[
+                    Client-side callback to be executed when a pointer button is released over the link.
+                ]]>
+            </description>
+            <name>onmouseup</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+    </tag>              
 </facelet-taglib>


### PR DESCRIPTION
OmniFaces currently lacks support for components that can render proper links to MultiViews pages. This pull request aims at filling that gap. Two components, `<o:link>` and `<o:button>`, as well as a supplementary component `<o:pathParam>`, are introduced herewith. Their aim is to offer an opportunity of generating links with path parameters to a MultiView-enabled page, the one that complements the MultiViews feature of FacesViews thus making it more usable. The components were created without using a Renderer and do the encoding directly within the component classes, so they are implementation-independent. The code has been tested for a variety of components, so it is provided as ready-to-use and drop-in. The documentation to the code is also supplied. If needed, showcase demos can also be created from the test usage code.