### PR TITLE
Fixing JBOSS_HOME property in Arquillian container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,22 @@
 			</resource>
 		</resources>
 
+		<testResources>
+			<testResource>
+				<directory>src/test/resources</directory>
+				<excludes>
+					<exclude>arquillian.xml</exclude>
+				</excludes>
+			</testResource>
+			<testResource>
+				<directory>src/test/resources</directory>
+				<includes>
+					<include>arquillian.xml</include>
+				</includes>
+				<filtering>true</filtering>
+			</testResource>
+		</testResources>
+
 		<plugins>
 
 			<!-- Add missing license headers to source files. -->
@@ -481,7 +497,6 @@
 						<artifactId>maven-failsafe-plugin</artifactId>
 						<configuration>
 							<systemPropertyVariables>
-								<jboss.home>${project.build.directory}/wildfly-${test.wildfly.version}</jboss.home>
 								<java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
 							</systemPropertyVariables>
 						</configuration>

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -21,6 +21,7 @@
 	<container qualifier="wildfly-managed" default="true">
 		<configuration>
 			<property name="serverConfig">standalone-ee8.xml</property>
+			<property name="jbossHome">${project.build.directory}/wildfly-${test.wildfly.version}</property>
 		</configuration>
 	</container>
 	<extension qualifier="webdriver">


### PR DESCRIPTION
JBOSS_HOME property is not resolved in Arquillian container if it is provided in `maven-failsafe-plugin` configuration. So it must be provided in `arquillian.xml`