### PR TITLE
Implement @JSParam annotation and injection support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,17 @@
 	</properties>
 
 	<dependencies>
-
+		<!-- Apache Commons dependencies. -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.8.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<version>4.3</version>
+		</dependency>
 		<!-- Java EE 8 dependencies. -->
 		<dependency>
 			<groupId>javax.faces</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,14 @@
 			<artifactId>commons-collections4</artifactId>
 			<version>4.3</version>
 		</dependency>
+
+		<!-- Other external dependencies. -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.9.8</version>
+		</dependency>
+
 		<!-- Java EE 8 dependencies. -->
 		<dependency>
 			<groupId>javax.faces</groupId>

--- a/src/main/java/org/omnifaces/cdi/JSParam.java
+++ b/src/main/java/org/omnifaces/cdi/JSParam.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
  *
  * <h3>Usage</h3>
  *
+ * <h4>Simple types</h4>
  * <p>
  * The example below injects the time zone offset of the client browser into <code>timezoneOffset</code>.
  * <pre>
@@ -40,6 +41,39 @@ import java.lang.annotation.Target;
  * &#64;Inject &#64;JSParam("window.screen.width")
  * private int screenWidth;
  * </pre>
+ *
+ * <h4>Complex types</h4>
+ * <p>
+ * <code>&#64;</code>{@link JSParam} also supports injection of complex JavaScript types. To make this work, an
+ * equivalent Java class needs to be defined and used as the injection point. The implementation uses Jackson to handle
+ * the mapping onto the Java object - so the defined class can use any of the Jackson specific JSON annotations to
+ * control the conversion.
+ * <pre>
+ * @JsonIgnoreProperties(ignoreUnknown = true)
+ * public static class Navigator {
+ *     @JsonProperty private String vendor;
+ *     @JsonProperty private String userAgent;
+ *     @JsonProperty private String language;
+ *
+ *     public getVendor() {
+ *         return vendor;
+ *     }
+ *
+ *     public getUserAgent() {
+ *         return userAgent;
+ *     }
+ *
+ *     public getLanguage() {
+ *         return language;
+ *     }
+ * }
+ *
+ * &#64;Inject &#64;JSParam("navigator")
+ * private Navigator navigator;
+ * </p>
+ * <p>
+ * Note that the implementation only traverses complex JavaScript types one level. However, if you need to recursively
+ * collect certain data, this can be done with some custom JavaScript code.
  *
  * @since 3.3
  * @author Adam Waldenberg, Ejwa Software/Hosting

--- a/src/main/java/org/omnifaces/cdi/JSParam.java
+++ b/src/main/java/org/omnifaces/cdi/JSParam.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * The CDI annotation <code>&#64;</code>{@link JSParam} allows you to inject client-side evaluated JavaScript results
+ * and make them readily available in a CDI managed bean.
+ * <p>
+ * A field or property annotated with <code>&#64;</code>{@link JSParam} will not be instantly available when the parent
+ * managed bean is initialized and <code>&#64;</code>{@link PostConstruct} is called. Instead, the value is injected as
+ * soon as initial page load has completed.
+ *
+ * <h3>Usage</h3>
+ *
+ * <p>
+ * The example below injects the time zone offset of the client browser into <code>timezoneOffset</code>.
+ * <pre>
+ * &#64;Inject &#64;JSParam("new Date().getTimezoneOffset()")
+ * private String timeZoneOffset;
+ * </pre>
+ * <p>
+ * You can also do something simpler (just injecting the already stored screen width of the client computer);
+ * <pre>
+ * &#64;Inject &#64;JSParam("window.screen.width")
+ * private int screenWidth;
+ * </pre>
+ *
+ * @since 3.3
+ * @author Adam Waldenberg, Ejwa Software/Hosting
+ * @see JSParamExtension
+ *
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JSParam {
+	String value();
+}

--- a/src/main/java/org/omnifaces/cdi/jsparam/JSParamActionListener.java
+++ b/src/main/java/org/omnifaces/cdi/jsparam/JSParamActionListener.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.cdi.jsparam;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.enterprise.inject.InjectionException;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.faces.component.html.HtmlInputHidden;
+import javax.faces.event.AbortProcessingException;
+import javax.faces.event.ActionEvent;
+import javax.faces.event.ActionListener;
+import org.omnifaces.util.Components;
+import org.omnifaces.util.Faces;
+
+public class JSParamActionListener implements ActionListener {
+	@Override
+	public void processAction(ActionEvent event) throws AbortProcessingException {
+		Components.getCurrentForm().getChildren().forEach(component -> {
+			final Object o = Components.getCurrentForm().getAttributes().get("instance");
+
+			if (component instanceof HtmlInputHidden) {
+				final HtmlInputHidden input = (HtmlInputHidden) component;
+				final String value = Faces.getRequestParameter(input.getClientId());
+				final AnnotatedField field = (AnnotatedField) input.getAttributes().get("field");
+				final Class<?> baseType = field.getJavaMember().getType();
+
+				field.getJavaMember().setAccessible(true);
+
+				try {
+					if (baseType == Integer.class || baseType == int.class) {
+						field.getJavaMember().setInt(o, Integer.parseInt(value));
+					} else if (baseType == String.class) {
+						field.getJavaMember().set(o, value);
+					} else {
+						field.getJavaMember().set(o,
+							new ObjectMapper().readValue(value, baseType)
+						);
+					}
+				} catch (IOException | IllegalAccessException | IllegalArgumentException ex) {
+					throw new InjectionException(ex);
+				}
+			}
+		});
+	}
+}

--- a/src/main/java/org/omnifaces/cdi/jsparam/JSParamExtension.java
+++ b/src/main/java/org/omnifaces/cdi/jsparam/JSParamExtension.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.cdi.jsparam;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.InjectionException;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.ProcessInjectionTarget;
+import javax.faces.component.UIComponent;
+import javax.faces.component.html.HtmlBody;
+import javax.faces.component.html.HtmlCommandScript;
+import javax.faces.component.html.HtmlForm;
+import javax.faces.component.html.HtmlInputHidden;
+import javax.faces.event.AbortProcessingException;
+import javax.faces.event.ActionEvent;
+import javax.faces.event.ActionListener;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.omnifaces.cdi.JSParam;
+import org.omnifaces.util.Components;
+import org.omnifaces.util.Faces;
+
+/**
+ * CDI extension that implements injection of client-side evaluated JavaScript results. The implementation is stateless,
+ * completely relying on the model provided and stored in the JSF component tree.
+ * <p>
+ * When initialized, the extension first checks if the body of the current view root contains a form suitable for
+ * passing the values collected from the specified javascript expressions. If a suitable {@link HtmlForm} form does not
+ * exist, one is created together with a {@link HtmlCommandScript}. The command script is also connected to a action
+ * listener that actually handles the injection logic - being called as soon as the page is loaded.
+ * Once done, the bean instance holding the injection points is checked for all<code>&#64;</code>{@link JSParam}
+ * properties defined in the class. Each property receives the JavaScript and hidden input fields needed to send the
+ * result of the evaluated expressions back to the CDI managed bean.
+ * 
+ * @since 3.3
+ * @author Adam Waldenberg, Ejwa Software/Hosting
+ */
+public class JSParamExtension implements Extension {
+	private static final int GENERATED_ID_NUM_CHARACTERS = 8;
+	private static final String JSPARAM_FORM_NAME = JSParam.class.getName().toLowerCase().replace('.', '-');
+	private static final String ASSIGNMENT_TEMPLATE = "document.getElementById('%s:%s').value = %s;";
+
+	private HtmlBody getDocumentBody() {
+		for (UIComponent c : Faces.getViewRoot().getChildren()) {
+			if (c instanceof HtmlBody) {
+				return (HtmlBody) c;
+			}
+		}
+
+		throw new IllegalStateException(String.format("The docoument %s does not contain a body",
+		                                              Faces.getContext().getViewRoot()));
+	}
+
+	private <T> void initializePageForm(T instance, Field field) {
+		if (Components.findComponent(JSPARAM_FORM_NAME) == null) {
+			final HtmlForm form = new HtmlForm();
+			final HtmlCommandScript commandScript = new HtmlCommandScript();
+
+			commandScript.addActionListener(new JSParamActionListener());
+			commandScript.setName(RandomStringUtils.randomAlphabetic(GENERATED_ID_NUM_CHARACTERS));
+			commandScript.setAutorun(true);
+			form.setStyle("display: none;");
+			form.setId(JSPARAM_FORM_NAME);
+			form.getChildren().add(commandScript);
+			getDocumentBody().getChildren().add(form);
+		}
+	}
+
+	private <T> void addHiddenComponent(T instance, AnnotatedField field) {
+		final HtmlForm form = (HtmlForm) Components.findComponent(JSPARAM_FORM_NAME);
+		final HtmlInputHidden input = new HtmlInputHidden();
+		input.setId(field.getJavaMember().getName());
+		input.getAttributes().put("field", field);
+		form.getAttributes().put("instance", instance);
+		form.getChildren().add(input);
+	}
+
+	private <T> void addScript(T instance, Field field) {
+		final Class<?> beanClass = field.getDeclaringClass();
+		final List<Field> fields = FieldUtils.getFieldsListWithAnnotation(beanClass, JSParam.class);
+		final Field lastField = IteratorUtils.get(fields.iterator(), fields.size() - 1);
+
+		if (field.equals(lastField)) {
+			final List<String> scripts = new ArrayList<>();
+
+			fields.forEach(f -> {
+				final String javascript = f.getAnnotation(JSParam.class).value();
+
+				scripts.add(String.format(ASSIGNMENT_TEMPLATE,
+					JSPARAM_FORM_NAME, f.getName(), javascript)
+				);
+			});
+
+			Components.addScriptToBody(StringUtils.join(scripts, "\n"));
+		}
+	}
+
+	public <T> void initializePropertyLoading(final @Observes ProcessInjectionTarget<T> pit) {
+		pit.getAnnotatedType().getFields().forEach(f -> {
+			final InjectionTarget<T> it = pit.getInjectionTarget();
+
+			if (f.getAnnotation(JSParam.class) != null) {
+				pit.setInjectionTarget(new InjectionTarget<T>() {
+					@Override
+					public void inject(T instance, CreationalContext<T> ctx) {
+						it.inject(instance, ctx);
+
+						initializePageForm(instance, f.getJavaMember());
+						addHiddenComponent(instance, f);
+						addScript(instance, f.getJavaMember());
+					}
+
+					@Override
+					public void postConstruct(T instance) {
+						it.postConstruct(instance);
+					}
+
+					@Override
+					public void preDestroy(T instance) {
+						it.dispose(instance);
+					}
+
+					@Override
+					public void dispose(T instance) {
+						it.dispose(instance);
+					}
+
+					@Override
+					public Set<InjectionPoint> getInjectionPoints() {
+						return it.getInjectionPoints();
+					}
+
+					@Override
+					public T produce(CreationalContext<T> ctx) {
+						return it.produce(ctx);
+					}
+				});
+			}
+		});
+	}
+
+	public static class JSParamActionListener implements ActionListener {
+		public JSParamActionListener() { /* Left blank on purpose */ }
+		
+		@Override
+		public void processAction(ActionEvent event) throws AbortProcessingException {
+			Components.getCurrentForm().getChildren().forEach(component -> {
+				final Object o = Components.getCurrentForm().getAttributes().get("instance");
+
+				if (component instanceof HtmlInputHidden) {
+					final HtmlInputHidden input = (HtmlInputHidden) component;
+					final String value = Faces.getRequestParameter(input.getClientId());
+					final AnnotatedField field = (AnnotatedField) input.getAttributes().get("field");
+					final Class<?> baseType = field.getJavaMember().getType();
+
+					field.getJavaMember().setAccessible(true);
+
+					try {
+						if (baseType == Integer.class || baseType == int.class) {
+							field.getJavaMember().setInt(o, Integer.parseInt(value));
+						} else {
+							field.getJavaMember().set(o, value);
+						}
+					} catch (IllegalAccessException | IllegalArgumentException ex) {
+						throw new InjectionException(ex);
+					}
+				}
+			});
+		}
+	}
+}

--- a/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,3 +1,4 @@
 org.omnifaces.cdi.viewscope.ViewScopeExtension
 org.omnifaces.cdi.eager.EagerExtension
 org.omnifaces.cdi.param.ParamExtension
+org.omnifaces.cdi.jsparam.JSParamExtension


### PR DESCRIPTION
This adds support for client-side evaulated JavaScript expressions. The result of those expressions are injected into the managed bean of the server once a page is loaded and the expressions are evaluated.

To use it you can do the following;
```
@JSParam("new Date().getTimezoneOffset()")
private int clientTimeZoneOffset;

@JSParam("window.screen.width")
private String screenWidth;
```

The implementation can now also handle complex types via the object mapper of Jackson (objects and dictionaries on the JavaScript side). To use it you can do the following;
```
@Data
@JsonIgnoreProperties(ignoreUnknown = true)
public static class Navigator {
    @JsonProperty private String vendor;
    @JsonProperty private String userAgent;
    @JsonProperty private String language;
}

@JSParam("navigator")
private Navigator navigator;
```

My reasoning for not relying on `@Inject` and making the annotation a qualifier is that this parameter is injected outside of the normal life-cycle, with the value being available only after the initial page request. So unlike most parameters injected with `@Inject`, these will not be available during `@PostConstruct`. Instead, they are available after page initialization and thus during callback events.

Obviously, there are some alternative solutions to this - but not without slowing down the whole loading of the page. One way of achieving this could be to send an extra asynchronous ajax request on page loads - however, it would still require us to wait for the result before continuing so I don't really consider it an alternative. Putting the parameter synchronization higher up in the page body is another. However, this would also affect the speed of page loads. The current solution felt like the best compromise.