### PR TITLE
Add stripTags method to Strings EL functions.

### DIFF
--- a/src/main/java/org/omnifaces/el/functions/Strings.java
+++ b/src/main/java/org/omnifaces/el/functions/Strings.java
@@ -276,6 +276,20 @@ public final class Strings {
 	}
 
 	/**
+	 * Remove XML tags from a string and return only plain text.
+	 * 
+	 * @param text Text with XML tags
+	 * @return The string without XML tags
+	 */
+	public static String stripTags(String text) {
+		if (text == null || text.isEmpty()) {
+			return "";
+		}
+
+		return text.replaceAll("\\<.*?\\>", "").replaceAll("\\s+", " ").trim();
+	}
+
+	/**
 	 * The main string format method taking varargs.
 	 */
 	private static String format(String pattern, Object... params) {

--- a/src/main/resources/META-INF/omnifaces-functions.taglib.xml
+++ b/src/main/resources/META-INF/omnifaces-functions.taglib.xml
@@ -211,6 +211,17 @@
 		<function-class>org.omnifaces.el.functions.Strings</function-class>
 		<function-signature>java.lang.String format5(java.lang.String, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)</function-signature>
 	</function>
+        
+        <function>
+                <description>
+                        <![CDATA[
+                                Remove XML tags from a given text and return plain text.
+                        ]]>
+                </description>
+                <function-name>stripTags</function-name>
+                <function-class>org.omnifaces.el.functions.Strings</function-class>
+                <function-signature>java.lang.String stripTags(java.lang.String)</function-signature>
+        </function>
 
 	<!-- Arrays =================================================================================================== -->
 

--- a/src/test/java/org/omnifaces/test/el/functions/TestStrings.java
+++ b/src/test/java/org/omnifaces/test/el/functions/TestStrings.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.test.el.functions;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.omnifaces.el.functions.Strings;
+
+public class TestStrings {
+    @Test
+    public void testStripTags() {
+        String textWithTags = "<div><p>Text with <strong>lots</strong> of "
+            + "<a href=\"http://example.com\" title=\"Link\">HTML</a> tags<br />"
+            + "<img src=\"tags.jpg\">. Random math: <code>x/y with y > 0</code> "
+            + "</p></div>";
+        String expectedText = "Text with lots of HTML tags. Random math: x/y with y > 0";
+
+        assertEquals(expectedText, Strings.stripTags(textWithTags));
+    }
+}


### PR DESCRIPTION
The method is inspired by PHP's [strip_tags](https://www.php.net/manual/en/function.strip-tags.php) method, removing (X)HTML tags from a given text and only returning plain text. 

It's useful for displaying user generated content as tooltips, image titles  or any situation where content originally containing (X)HTML needs to be displayed without any (X)HTML tags. 
