### PR TITLE
Relocate json encode

### DIFF
--- a/src/main/java/org/omnifaces/cdi/push/SocketPushContext.java
+++ b/src/main/java/org/omnifaces/cdi/push/SocketPushContext.java
@@ -85,13 +85,16 @@ public class SocketPushContext implements PushContext {
 	@Override
 	public <S extends Serializable> Map<S, Set<Future<Void>>> send(Object message, Collection<S> users) {
 		Map<S, Set<Future<Void>>> resultsByUser = new HashMap<>(users.size());
-
+		
+		//move json creation for avoiding create json string n-times about the collection size
+		String json = Json.encode(message);
+		
 		for (S user : users) {
 			Set<String> channelIds = socketUsers.getChannelIds(user, channel);
 			Set<Future<Void>> results = new HashSet<>(channelIds.size());
 
 			for (String channelId : channelIds) {
-				results.addAll(socketSessions.send(channelId, message));
+				results.addAll(socketSessions.send(channelId, json));
 			}
 
 			resultsByUser.put(user, results);

--- a/src/main/java/org/omnifaces/cdi/push/SocketSessionManager.java
+++ b/src/main/java/org/omnifaces/cdi/push/SocketSessionManager.java
@@ -136,12 +136,11 @@ public class SocketSessionManager {
 	 * with given channel identifier. The returned futures will return <code>null</code> on {@link Future#get()} if the
 	 * message was successfully delivered and otherwise throw {@link ExecutionException}.
 	 */
-	protected Set<Future<Void>> send(String channelId, Object message) {
+	protected Set<Future<Void>> send(String channelId, String message) {
 		Collection<Session> sessions = (channelId != null) ? socketSessions.get(channelId) : null;
 
 		if (sessions != null && !sessions.isEmpty()) {
 			Set<Future<Void>> results = new HashSet<>(sessions.size());
-			String json = Json.encode(message);
 
 			for (Session session : sessions) {
 				if (session.isOpen()) {


### PR DESCRIPTION
I moved json encode for avoiding create json string n-times. With this change the json string is created once. before if the user list has 100 elements then the json was encoded 100 times. With this change the json string is encode once.