### PR TITLE
Optimized JNDIObjectLocator memory usage

### DIFF
--- a/src/main/java/org/omnifaces/util/Beans.java
+++ b/src/main/java/org/omnifaces/util/Beans.java
@@ -382,14 +382,13 @@ public final class Beans {
 	}
 
 	/**
-	 * Returns whether given bean class is a remote EJB. That is, when the <code>javax.ejb.Remote</code> annotation is present on the given type.
+	 * Returns whether given bean class has the given annotation is present
 	 * @param beanClass The bean class.
-	 * @return Whether given bean class is a remote EJB.
+         * @param annotation to check, may be null
+	 * @return annotation is present on the type
 	 * @since 3.9
 	 */
-	public static boolean isRemoteEJB(Class<?> beanClass) {
-		Class<? extends Annotation> remoteAnnotation = toClassOrNull("javax.ejb.Remote");
-		return remoteAnnotation != null && beanClass.isAnnotationPresent(remoteAnnotation);
+	public static boolean isAnnotationPresent(Class<?> beanClass, Class<? extends Annotation> annotation) {
+		return annotation != null && beanClass.isAnnotationPresent(annotation);
 	}
-
 }


### PR DESCRIPTION
removed secondary cache, optimized remote ejb lookup so it's not necessary