### PR TITLE
Added format property to validateBean

### DIFF
--- a/src/main/java/org/omnifaces/taghandler/ValidateBean.java
+++ b/src/main/java/org/omnifaces/taghandler/ValidateBean.java
@@ -261,6 +261,23 @@ import org.omnifaces.util.copier.SerializationCopier;
  * The <code>showMessageFor</code> attribute is new since OmniFaces 2.6 and it defaults to <code>@form</code>. The
  * <code>showMessageFor</code> attribute does by design not have any effect when <code>validateMethod="actual"</code>
  * is used.
+ * 
+ * <p>
+ * The faces message usualy follows a predetermined formatting, which corresponds to the value of <code>BeanValidator.MESSAGE_ID</code>.
+ * The default format String typically prepends all the validated labels which were checked when the error message occurred, which is 
+ * useful in the case of validating a single variable, but sometimes confusing in the case of validating a bean with many properties.
+ * 
+ * In a form containing properties like First Name, Last Name, Address, Zip Code, and Phone Number where at the bean level, at least one of
+ * the name fields must be non-null, overriding the format String can help make a more clear error message.
+ * 
+ * <pre>
+ *      &lt;!-- Displays: "First Name Last Name Address Zip Code Phone Number First Name and Last Name cannot both be null" --&gt;
+ *      &lt;o:validateBean /&gt;
+ * 
+ *      &lt;!-- Displays: "Errors encountered: First Name and Last Name cannot both be null" --&gt;
+ *      &lt;o:validateBean format="Errors encountered: {0}" /&gt;"
+ * </pre>
+ * </p>
  *
  * @author Bauke Scholtz
  * @author Arjan Tijms
@@ -302,6 +319,7 @@ public class ValidateBean extends TagHandler {
 	private String groups;
 	private String copier;
 	private String showMessageFor;
+    private String format;
 
 	// Constructors ---------------------------------------------------------------------------------------------------
 
@@ -339,6 +357,7 @@ public class ValidateBean extends TagHandler {
 		method = ValidateMethod.of(getString(context, getAttribute("method")));
 		groups = getString(context, getAttribute("validationGroups"));
 		copier = getString(context, getAttribute("copier"));
+        format = getString(context, getAttribute("format"));
 		showMessageFor = coalesce(getString(context, getAttribute("showMessageFor")), DEFAULT_SHOWMESSAGEFOR);
 
 		// We can't use getCurrentForm() or hasInvokedSubmit() before the component is added to view, because the client ID isn't available.
@@ -491,10 +510,10 @@ public class ValidateBean extends TagHandler {
 				invalidateInputsByPropertyPathAndShowMessages(context, form, actualBean, violations);
 			}
 			else if (showMessageFor.charAt(0) != '@') {
-				invalidateInputsByShowMessageForAndShowMessages(context, form, violations, showMessageFor);
+				invalidateInputsByShowMessageForAndShowMessages(context, form, violations, showMessageFor, format);
 			}
 			else {
-				invalidateInputsByClientIdsAndShowMessages(context, form, violations, clientIds, showMessageFor);
+				invalidateInputsByClientIdsAndShowMessages(context, form, violations, clientIds, showMessageFor, format);
 			}
 
 			if (context.isValidationFailed() && renderResponseOnFail) {
@@ -567,7 +586,7 @@ public class ValidateBean extends TagHandler {
 		return copier;
 	}
 
-	private static void invalidateInputsByPropertyPathAndShowMessages(FacesContext context, UIForm form, Object bean, Set<ConstraintViolation<?>> violations) {
+	private static void invalidateInputsByPropertyPathAndShowMessages(FacesContext context, UIForm form, Object bean, Set<ConstraintViolation<?>> violations, String format) {
 		for (ConstraintViolation<?> violation : violations) {
 			Object base = resolveViolatedBase(bean, violation);
 			String property = resolveViolatedProperty(violation);
@@ -576,12 +595,12 @@ public class ValidateBean extends TagHandler {
 				context.validationFailed();
 				input.setValid(false);
 				String clientId = input.getClientId(context);
-				addError(clientId, formatMessage(violation.getMessage(), getLabel(input)));
+				addError(clientId, formatMessage(violation.getMessage(), getLabel(input), format));
 			});
 		}
 	}
 
-	private static void invalidateInputsByShowMessageForAndShowMessages(FacesContext context, UIForm form, Set<ConstraintViolation<?>> violations, String showMessageFor) {
+	private static void invalidateInputsByShowMessageForAndShowMessages(FacesContext context, UIForm form, Set<ConstraintViolation<?>> violations, String showMessageFor, String format) {
 		for (String forId : showMessageFor.split("\\s+")) {
 			UIComponent component = form.findComponent(forId);
 			context.validationFailed();
@@ -591,11 +610,11 @@ public class ValidateBean extends TagHandler {
 			}
 
 			String clientId = component.getClientId(context);
-			addErrors(clientId, violations, getLabel(component));
+			addErrors(clientId, violations, getLabel(component), format);
 		}
 	}
 
-	private static void invalidateInputsByClientIdsAndShowMessages(final FacesContext context, UIForm form, Set<ConstraintViolation<?>> violations, Set<String> clientIds, String showMessageFor) {
+	private static void invalidateInputsByClientIdsAndShowMessages(final FacesContext context, UIForm form, Set<ConstraintViolation<?>> violations, Set<String> clientIds, String showMessageFor, String format) {
 		context.validationFailed();
 		StringBuilder labels = new StringBuilder();
 
@@ -611,43 +630,43 @@ public class ValidateBean extends TagHandler {
 			});
 		}
 
-		showMessages(context, form, violations, clientIds, labels.toString(), showMessageFor);
+		showMessages(context, form, violations, clientIds, labels.toString(), showMessageFor, format);
 	}
 
-	private static void showMessages(FacesContext context, UIForm form, Set<ConstraintViolation<?>> violations, Set<String> clientIds, String labels, String showMessagesFor) {
+	private static void showMessages(FacesContext context, UIForm form, Set<ConstraintViolation<?>> violations, Set<String> clientIds, String labels, String showMessagesFor, String format) {
 		if ("@form".equals(showMessagesFor)) {
 			String formId = form.getClientId(context);
-			addErrors(formId, violations, labels);
+			addErrors(formId, violations, labels, format);
 		}
 		else if ("@all".equals(showMessagesFor)) {
 			for (String clientId : clientIds) {
-				addErrors(clientId, violations, labels);
+				addErrors(clientId, violations, labels, format);
 			}
 		}
 		else if ("@global".equals(showMessagesFor)) {
 			for (ConstraintViolation<?> violation : violations) {
-				addGlobalError(formatMessage(violation.getMessage(), labels));
+				addGlobalError(formatMessage(violation.getMessage(), labels, format));
 			}
 		}
 		else {
 			for (String clientId : showMessagesFor.split("\\s+")) {
-				addErrors(clientId, violations, labels);
+				addErrors(clientId, violations, labels, format);
 			}
 		}
 	}
 
-	private static void addErrors(String clientId, Set<ConstraintViolation<?>> violations, String labels) {
+	private static void addErrors(String clientId, Set<ConstraintViolation<?>> violations, String labels, String format) {
 		for (ConstraintViolation<?> violation : violations) {
-			addError(clientId, formatMessage(violation.getMessage(), labels));
+			addError(clientId, formatMessage(violation.getMessage(), labels, format));
 		}
 	}
 
-	private static String formatMessage(String message, String label) {
+	private static String formatMessage(String message, String label, String format) {
 		if (!isEmpty(label)) {
 			ResourceBundle messageBundle = getMessageBundle();
 
 			if (messageBundle != null && messageBundle.containsKey(BeanValidator.MESSAGE_ID)) {
-				String pattern = messageBundle.getString(BeanValidator.MESSAGE_ID);
+				String pattern = format != null ? format : messageBundle.getString(BeanValidator.MESSAGE_ID);
 
 				if (pattern != null) {
 					return format(pattern, message, label);

--- a/src/main/resources/META-INF/omnifaces-ui.taglib.xml
+++ b/src/main/resources/META-INF/omnifaces-ui.taglib.xml
@@ -5158,6 +5158,20 @@ public enum Baz {
 			<required>false</required>
 			<type>java.lang.String</type>
 		</attribute>
+        <attribute>
+			<description>
+				<![CDATA[
+					The format String which should be used to display error messages occurring as a result of bean validation.
+                    The default format String is set differently depending on the systems used, but typically involves prepending
+                    a list of labels for the verified fields before showing the error message. If this default results in a
+                    confusing error message, it may be overridden here, using <code>{0}</code> to represent the error description
+                    and <code>{1}</code> to represent the label/list of labels associated with the validation.
+				]]>
+			</description>
+			<name>format</name>
+			<required>false</required>
+			<type>java.lang.String</type>
+		</attribute>
 	</tag>
 
 	<tag>


### PR DESCRIPTION
## Added `format` property to `validateBean`

### The Problem Statement
When calling `validateBean` on the input for an entire form, the error message thrown when validation fails will always include a prepended list of the labels whose values were validated. This is an artifact of the typical single-value validation error message structure, which tends to work automatically.

For instance, if one is validating that the `address` property is not null, then the error message will consist of two parts: the label for the address "Address" and the predetermined error message for non-null values "cannot be null". Put together, the error message will read "Address cannot be null", which is a nice a descriptive message. 

However, in the case of validating a bean, and especially when that validation occurs on a form submit where lots of properties are validated at once, the prepended list of label names becomes more confusing and cumbersome than helpful. A common bean validation criterion might be that one field could be null, but both of the fields cannot be null. If validating a form containing the fields First Name, Last Name, Address, Zip Code, and Phone Number, and validating that at least First Name or Last Name has a non-null value, the error message for `validateBean` without any formatting may look like this:

    "First Name Last Name Address Zip Code Phone Number Either First Name or Last Name must not be null."

This error message is difficult to parse, and the difficulty is compounded if and when the labels for a form may contain slightly different wordings for variable names. (Imagine the confusion if instead of "First Name" the label read "Please enter the client's First Name" or similar!)

**Evidence**

I have written up a pet project just to get a good, non-corporate example of how the feature works. Here is evidence of the problem in the current implementation of Omnifaces.

![Error message default formatting](https://user-images.githubusercontent.com/22013543/140780139-ffe6c5af-b45a-4656-a953-0e7c34cf653f.png)

### The Solution
Unfortunately, the format String for an error message is relatively difficult to touch. The default for all error messages is stored in a particular location, and that string is always used for the `formatMessage` method within `ValidateBean`. This means that changing the format String for just one error message will change the format String for _all_ error messages, even though it's very useful in the not-whole-bean, nicely-worded-label happy path case.

The existing logic within `validateBean` allows for a special case where if there are no labels associated with the validated fields, then it simply displays the error messages associated with the fields. Technically, to get the desired output for a whole bean validation, one could manipulate the form so as to not _technically_ include labels for the fields, but this promotes what would typically be considered bad practice.

Instead, it would be possible to change the logic within the `formatMessage` method so that it selects the appropriate format String without always using the default. An additional field might be passed in attached to the `validateBean` tag which can replace the default format String when not null. Then, one could pass in a variety of format Strings for just this validation, and could leverage that modularity to customize the types of error messages displayed, too. Here are some examples:

When using `format="{0}"`:

    "Either First Name or Last Name must not be null."

When using `format="Errors encountered while saving the form: {0}"`:

    "Errors encountered while saving the form: Either First Name or Last Name must not be null."

This output would be shown regardless of poor label naming and leaves open the possibility of using the old default format String for other individual-field error messages.

**Evidence** 

In my pet project, I imported a changed version of Omnifaces with my fix, and was able to see a positive change.

![Error message custom formatting](https://user-images.githubusercontent.com/22013543/140780330-db88f745-5953-4d95-b2eb-d69135bbca82.png)

*After review, I see that between taking screenshots, I updated the error message to specify that the validation was happening with String1 and String2. I think this doesn't change that the fix works, but technically the images could be misleading. My apologies!*

### Next Steps

Thank you for taking a look at this PR- this is the first time I've contributed to an open-source project, so I'm a bit unfamiliar with the process. I have tried to add documentation where appropriate, and have taken a couple hints from previously merged PRs here in Omnifaces. I'm open to feedback and criticism, and would like to be able to move along with this code change in as efficient and rapid a manner as possible. Please let me know if there are things that need to change in order to merge, or if there is a process I'm not adequately following.