### PR TITLE
Fixed malformedXML Error in Ajax.updateRowCells

### DIFF
--- a/src/main/java/org/omnifaces/util/Ajax.java
+++ b/src/main/java/org/omnifaces/util/Ajax.java
@@ -196,6 +196,8 @@ public final class Ajax {
 
 		for (UIComponent column : table.getChildren()) {
 			if (column instanceof UIColumn) {
+				if (!column.isRendered()) continue;
+
 				for (UIComponent cell : column.getChildren()) {
 					renderIds.add(format("%s%c%d%c%s", tableId, separator, index, separator, cell.getId()));
 				}

--- a/src/main/java/org/omnifaces/util/Ajax.java
+++ b/src/main/java/org/omnifaces/util/Ajax.java
@@ -190,7 +190,8 @@ public final class Ajax {
 
 	private static void updateRowCells(UIData table, int index) {
 		FacesContext context = FacesContext.getCurrentInstance();
-		String tableId = table.getClientId(context);
+		String parentId = table.getParent().getClientId();
+		String tableId = table.getId();
 		char separator = UINamingContainer.getSeparatorChar(context);
 		Collection<String> renderIds = getContext().getRenderIds();
 
@@ -199,7 +200,7 @@ public final class Ajax {
 				if (!column.isRendered()) continue;
 
 				for (UIComponent cell : column.getChildren()) {
-					renderIds.add(format("%s%c%d%c%s", tableId, separator, index, separator, cell.getId()));
+					renderIds.add(format("%s%c%s%c%d%c%s", parentId, separator, tableId, separator, index, separator, cell.getId()));
 				}
 			}
 			else if (column instanceof UIData) { // <p:columns>.
@@ -249,7 +250,8 @@ public final class Ajax {
 
 	private static void updateColumnCells(UIData table, int index, int rowCount) {
 		FacesContext context = FacesContext.getCurrentInstance();
-		String tableId = table.getClientId(context);
+		String parentId = table.getParent().getClientId();
+		String tableId = table.getId();
 		char separator = UINamingContainer.getSeparatorChar(context);
 		Collection<String> renderIds = getContext().getRenderIds();
 		UIColumn column = findColumn(table, index);
@@ -259,7 +261,7 @@ public final class Ajax {
 				String cellId = cell.getId();
 
 				for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-					renderIds.add(format("%s%c%d%c%s", tableId, separator, rowIndex, separator, cellId));
+					renderIds.add(format("%s%c%s%c%d%c%s", parentId, separator, tableId, separator, rowIndex, separator, cellId));
 				}
 			}
 		}


### PR DESCRIPTION
When a <code><h:column rendered="false"></code> exists inside a table, a malformedXML Error appears in the browser as soon as we use <code>Ajax.updateRow()</code> on it.
If we check <code>column.isRendered()</code>, the non-rendered columns are left out and therefore the error disappears.


The second commit fixes a problem that appears when calling the <code>updateRow</code>/<code>updateColumn</code> Methods using a Button sitting inside the <code><h:dataTable></code> itself. It can easily be replicated using the example from [Omnifaces Showcase](https://showcase.omnifaces.org/utils/Ajax) by moving the <code><h:commandButton></code> to the first <code><h:column></code>.
The Problem is that <code>getClientId()</code> will attach the rowIndex to the Id, resulting in (e.g.) <code>form:dataTable:1</code> instead of <code>form:dataTable</code>. That way the rerender will fail.