### PR TITLE
Add tomcat env support

### DIFF
--- a/src/main/java/org/omnifaces/util/Beans.java
+++ b/src/main/java/org/omnifaces/util/Beans.java
@@ -107,7 +107,7 @@ public final class Beans {
 		}
 		catch (Exception | LinkageError e) {
 			logger.log(FINE, "Cannot get BeanManager from CDI.current(); falling back to JNDI.", e);
-			return JNDI.lookup("java:comp/BeanManager");
+			return JNDI.lookup(Hacks.isTomcat() ? "java:comp/env/BeanManager" : "java:comp/BeanManager");
 		}
 	}
 

--- a/src/main/java/org/omnifaces/util/Hacks.java
+++ b/src/main/java/org/omnifaces/util/Hacks.java
@@ -452,6 +452,18 @@ public final class Hacks {
 	}
 
 	// Tomcat related -------------------------------------------------------------------------------------------------
+	
+	/**
+	 * @return {@code true} if we are running in an environment with Tomcat servlet container classes
+	 */
+	public static boolean isTomcat() {
+		try {
+			Class.forName("org.apache.catalina.Container");
+			return true;
+		} catch (ClassNotFoundException e) {
+			return false;
+		}
+	}
 
 	/**
 	 * Returns true if the given WS session is from Tomcat and given illegal state exception is caused by a push bomb


### PR DESCRIPTION
Added logic to account for the CDI BeanManager being located at java:comp/env/BeanManager instead of java:comp/BeanManager when running in a Tomcat servlet container.