### PR TITLE
Added web.xml context parameter to disable environment initialization checks

### DIFF
--- a/src/main/java/org/omnifaces/ApplicationInitializer.java
+++ b/src/main/java/org/omnifaces/ApplicationInitializer.java
@@ -47,11 +47,16 @@ public class ApplicationInitializer implements ServletContainerInitializer {
 
 	static final String ERROR_OMNIFACES_INITIALIZATION_FAIL =
 		"OmniFaces failed to initialize! Report an issue to OmniFaces.";
+	static final String DISABLE_ENV_INIT_CHECKS = "org.omnifaces.DISABLE_ENV_INIT_CHECKS";
 
 	// Actions --------------------------------------------------------------------------------------------------------
 
 	@Override
 	public void onStartup(Set<Class<?>> c, ServletContext servletContext) throws ServletException {
+		if (isOmniFacesDisabled(servletContext)) {
+			logger.info("OmniFaces initialization is disabled");
+			return;
+		}
 		logOmniFacesVersion();
 
 		try {
@@ -67,4 +72,7 @@ public class ApplicationInitializer implements ServletContainerInitializer {
 		logger.info("Using OmniFaces version " + OmniFaces.getVersion());
 	}
 
+	static boolean isOmniFacesDisabled(ServletContext servletContext) {
+		return Boolean.parseBoolean(servletContext.getInitParameter(DISABLE_ENV_INIT_CHECKS));
+	}
 }

--- a/src/main/java/org/omnifaces/ApplicationListener.java
+++ b/src/main/java/org/omnifaces/ApplicationListener.java
@@ -32,6 +32,7 @@ import org.omnifaces.facesviews.FacesViews;
 import org.omnifaces.resourcehandler.GraphicResource;
 import org.omnifaces.resourcehandler.ViewResourceHandler;
 import org.omnifaces.util.cache.CacheInitializer;
+import static org.omnifaces.ApplicationInitializer.isOmniFacesDisabled;
 
 /**
  * <p>
@@ -75,6 +76,9 @@ public class ApplicationListener extends DefaultServletContextListener {
 
 	@Override
 	public void contextInitialized(ServletContextEvent event) {
+		if (isOmniFacesDisabled(event.getServletContext())) {
+			return;
+		}
 		checkJSF23Available();
 		checkCDI11Available();
 


### PR DESCRIPTION
Fixes #703 

In order not to fail initialization, add the following context parameter:

```
    <context-param>
        <param-name>org.omnifaces.DISABLE_ENV_INIT_CHECKS</param-name>
        <param-value>true</param-value>
    </context-param>
```