### PR TITLE
Fix #710: Standardize welcome files lookup

### DIFF
--- a/src/main/java/org/omnifaces/ApplicationProcessor.java
+++ b/src/main/java/org/omnifaces/ApplicationProcessor.java
@@ -73,7 +73,7 @@ public class ApplicationProcessor implements SystemEventListener {
 		try {
 			Application application = (Application) event.getSource();
 			checkDuplicateResourceHandler();
-			FacesViews.registerViewHander(servletContext, application);
+			FacesViews.registerViewHandler(servletContext, application);
 			MessagesKeywordResolver.register(application);
 		}
 		catch (Exception | LinkageError e) {

--- a/src/main/java/org/omnifaces/config/WebXml.java
+++ b/src/main/java/org/omnifaces/config/WebXml.java
@@ -67,6 +67,12 @@ import org.omnifaces.cdi.config.WebXmlProducer;
  */
 public interface WebXml {
 
+	// Public constants ------------------------------------------------------------------------------------------------
+	String WEB_XML = "/WEB-INF/web.xml";
+	String QUARKUS_WEB_XML = "META-INF/web.xml";
+	String WEB_FRAGMENT_XML = "META-INF/web-fragment.xml";
+	String XPATH_WELCOME_FILE = "welcome-file-list/welcome-file";
+
 	// Enum singleton -------------------------------------------------------------------------------------------------
 
 	/**

--- a/src/main/java/org/omnifaces/config/WebXmlSingleton.java
+++ b/src/main/java/org/omnifaces/config/WebXmlSingleton.java
@@ -62,13 +62,6 @@ enum WebXmlSingleton implements WebXml {
 	INSTANCE;
 
 	// Private constants ----------------------------------------------------------------------------------------------
-
-	private static final String WEB_XML = "/WEB-INF/web.xml";
-	private static final String QUARKUS_WEB_XML = "META-INF/web.xml";
-	private static final String WEB_FRAGMENT_XML = "META-INF/web-fragment.xml";
-
-	private static final String XPATH_WELCOME_FILE =
-		"welcome-file-list/welcome-file";
 	private static final String XPATH_EXCEPTION_TYPE =
 		"error-page/exception-type";
 	private static final String XPATH_LOCATION =


### PR DESCRIPTION
Fix #710: Standardize welcome files lookup

This fixes the welcome file lookup for Quarkus by re-using code that was already in `WebXmlSingleton`