### PR TITLE
Fix build for Maven 3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
 				<artifactId>frontend-maven-plugin</artifactId>
 				<version>1.12.1</version>
 				<configuration>
-					<nodeVersion>v4.6.0</nodeVersion>
+					<nodeVersion>v18.15.0</nodeVersion>
 					<installDirectory>target</installDirectory>
 				</configuration>
 				<executions>
@@ -296,6 +296,13 @@
 					<nosuffix>true</nosuffix>
 					<jsEngine>CLOSURE</jsEngine>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.plexus</groupId>
+						<artifactId>plexus-utils</artifactId>
+						<version>3.5.0</version>
+					</dependency>
+				</dependencies>
 				<executions>
 					<execution>
 						<id>minify-omnifaces</id>


### PR DESCRIPTION
@BalusC i tried to build on my new Windows 11 machine using Maven 3.9.1 and had 2 failures.

1. NodeJS reporting an SSL failure had to upgrade NodeJS
2. See: https://github.com/samaxes/minify-maven-plugin/pull/176  The minify plugin needs Plexus which is no longer included in 3.9.1 cc @blutorange

