### PR TITLE
Form.ts Issue #810

### DIFF
--- a/src/main/resources/META-INF/resources/omnifaces/omnifaces.js/Form.ts
+++ b/src/main/resources/META-INF/resources/omnifaces/omnifaces.js/Form.ts
@@ -76,11 +76,11 @@ export module Form {
     }
 
     function containsNamedChild(executeIds: string[], key: string) {
-        var name = key.replace("%3A", "\\:");
+        const name = key.replaceAll("%3A", "\\:");
 
         try {
-            for (let executeId of executeIds) {
-                var parent = document.getElementById(executeId);
+            for (const executeId of executeIds) {
+                const parent = document.getElementById(executeId);
 
                 if (parent && parent.querySelector("[name='" + name + "']")) {
                     return true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2021",
     "module": "commonjs",
     "rootDir": "src/main/resources/META-INF/resources/omnifaces/omnifaces.js",
     "outDir": "target/tsc",


### PR DESCRIPTION
Fix for https://github.com/omnifaces/omnifaces/issues/810

This fix brings the TS config from **es5** to **ES2021**, 
which at the moment of writing [it's quite old and should be safe for everyone](https://caniuse.com/mdn-javascript_builtins_string_replaceall).  

If you would stay on **es5**, then you have use a regex because there is no `replaceAll` function...