### PR TITLE
BeanStorage destroyBeans without explicit synchronized

### DIFF
--- a/src/main/java/org/omnifaces/cdi/BeanStorage.java
+++ b/src/main/java/org/omnifaces/cdi/BeanStorage.java
@@ -12,14 +12,15 @@
  */
 package org.omnifaces.cdi;
 
-import static org.omnifaces.util.Beans.destroy;
-
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.PassivationCapable;
+
+import org.omnifaces.util.Beans;
 
 /**
  * CDI bean storage. This class is theoretically reusable for multiple CDI scopes. It's currently however only used by
@@ -100,12 +101,13 @@ public class BeanStorage implements Serializable {
     /**
      * Destroy all beans managed so far.
      */
-    public synchronized void destroyBeans() { // Not sure if synchronization is absolutely necessary. Just to be on safe side.
-        for (Object bean : beans.values()) {
-            destroy(bean);
-        }
-
-        beans.clear();
+    public void destroyBeans() { // Not sure if synchronization is absolutely necessary...
+        // by using ConcurrentHashMap.keySet + remove(),
+        // should be safe to not use synchronization on the method
+        beans.keySet().stream()
+                      .map(beans::remove)
+                      .filter(Objects::nonNull)
+                      .forEach(Beans::destroy);
     }
 
 }


### PR DESCRIPTION
The idea is to use the ConcurrentMap keySet combined with the remove method

what do you think?