### PR TITLE
Components internal helpers methods for UINamingContainer use local cached values

### DIFF
--- a/src/main/java/org/omnifaces/util/Components.java
+++ b/src/main/java/org/omnifaces/util/Components.java
@@ -1889,11 +1889,27 @@ public final class Components {
         return getIterationIndexPattern().matcher(clientId).matches();
     }
 
+    private static Pattern ITERATION_INDEX_PATTERN = null;
+
     private static Pattern getIterationIndexPattern() {
-        return getApplicationAttribute("omnifaces.IterationIndexPattern", () -> {
-            String separatorChar = Character.toString(UINamingContainer.getSeparatorChar(getContext()));
-            return Pattern.compile("(^|.*" + quote(separatorChar) + ")([0-9]+" + quote(separatorChar) + ")(.*)");
-        });
+        if (ITERATION_INDEX_PATTERN == null) {
+            String separatorCharQuoted = quote(getSeparatorChar());
+            ITERATION_INDEX_PATTERN = getApplicationAttribute("omnifaces.IterationIndexPattern", () -> Pattern.compile("(^|.*" + separatorCharQuoted + ")([0-9]+" + separatorCharQuoted + ")(.*)"));
+        }
+
+        return ITERATION_INDEX_PATTERN;
+    }
+
+    private static String SEPARATOR_CHAR = null;
+
+    /**
+     * @return the {@link UINamingContainer} separator char and cache the value for this Application
+     */
+    private static String getSeparatorChar() {
+        if (SEPARATOR_CHAR == null) {
+            SEPARATOR_CHAR = Character.toString(UINamingContainer.getSeparatorChar(getContext()));
+        }
+        return SEPARATOR_CHAR;
     }
 
     /**

--- a/src/main/java/org/omnifaces/util/Components.java
+++ b/src/main/java/org/omnifaces/util/Components.java
@@ -1891,9 +1891,12 @@ public final class Components {
 
     private static Pattern ITERATION_INDEX_PATTERN = null;
 
+    /**
+     * @return the {@link Pattern} to match the iteration index and cache the value
+     */
     private static Pattern getIterationIndexPattern() {
         if (ITERATION_INDEX_PATTERN == null) {
-            String separatorCharQuoted = quote(getSeparatorChar());
+            final String separatorCharQuoted = quote(getSeparatorChar());
             ITERATION_INDEX_PATTERN = getApplicationAttribute("omnifaces.IterationIndexPattern", () -> Pattern.compile("(^|.*" + separatorCharQuoted + ")([0-9]+" + separatorCharQuoted + ")(.*)"));
         }
 
@@ -1903,7 +1906,7 @@ public final class Components {
     private static String SEPARATOR_CHAR = null;
 
     /**
-     * @return the {@link UINamingContainer} separator char and cache the value for this Application
+     * @return the {@link UINamingContainer} separator char and cache the value
      */
     private static String getSeparatorChar() {
         if (SEPARATOR_CHAR == null) {


### PR DESCRIPTION

`UINamingContainer.getSeparatorChar(FacesContext context)`
uses a init parameter to retrieve the value.

https://github.com/jakartaee/faces/issues/1971

Inside `Components` we could cache the value
instead of retrieve it multiple times, 
the same goes for the associated "iteration index" `Pattern`
that is being recreated every time ...


