### PR TITLE
Socket manager optimization and null check

### DIFF
--- a/src/main/java/org/omnifaces/cdi/push/SocketSessionManager.java
+++ b/src/main/java/org/omnifaces/cdi/push/SocketSessionManager.java
@@ -24,6 +24,7 @@ import static org.omnifaces.util.Beans.getReference;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,9 +87,7 @@ public class SocketSessionManager {
      * @param channelId The channel identifier to register.
      */
     protected void register(String channelId) {
-        if (!socketSessions.containsKey(channelId)) {
-            socketSessions.putIfAbsent(channelId, new ConcurrentLinkedQueue<>());
-        }
+        socketSessions.computeIfAbsent(channelId, ($) -> new ConcurrentLinkedQueue<>());
     }
 
     /**
@@ -136,7 +135,10 @@ public class SocketSessionManager {
         var sessions = channelId != null ? socketSessions.get(channelId) : null;
 
         if (sessions != null) {
-            return sessions.stream().filter(Session::isOpen).map(session -> send(session, message, true)).collect(toUnmodifiableSet());
+            return sessions.stream().filter(Session::isOpen)
+                                    .map(session -> send(session, message, true)) // can be null!
+                                    .filter(Objects::nonNull)
+                                    .collect(toUnmodifiableSet());
         }
 
         return emptySet();


### PR DESCRIPTION
1) Removed all `synchronized` blocks and `containsKey` double checks
2) Avoid NPE if the return of `SocketSessionManager.send` operation is null