### PR TITLE
Fix for #879 (accept type string for source parameter of faces.ajax.request)

### DIFF
--- a/src/main/resources/META-INF/resources/omnifaces/omnifaces.js/Form.ts
+++ b/src/main/resources/META-INF/resources/omnifaces/omnifaces.js/Form.ts
@@ -32,7 +32,7 @@ export module Form {
         if (faces) { // Standard JSF API.
             const originalAjaxRequest = faces.ajax.request;
 
-            faces.ajax.request = function(source: HTMLElement, event: any, options: any) {
+            faces.ajax.request = function(source: HTMLElement | string, event: any, options: any) {
                 const originalGetViewState = faces.getViewState;
 
                 faces.getViewState = function(form: HTMLFormElement) {
@@ -52,7 +52,8 @@ export module Form {
                     let encodedExecuteIds: string[] = [];
 
                     if (execute.indexOf("@none") == -1) {
-                        executeIds = execute.replace("@this", source.id).split(" ");
+                        const sourceId = source instanceof HTMLElement ? source.id : source
+                        executeIds = execute.replace("@this", sourceId).split(" ");
                         encodedExecuteIds = executeIds.map(encodeURIComponent);
                     }
 


### PR DESCRIPTION
Fixes failing containsNamedChild comparison in Form.ts when faces.ajax.request is called with source type string and execute contains "@this".