### PR TITLE
Fix index out of bounds error

### DIFF
--- a/src/main/java/org/omnifaces/util/FacesLocal.java
+++ b/src/main/java/org/omnifaces/util/FacesLocal.java
@@ -154,11 +154,25 @@ public final class FacesLocal {
 	private static final int DEFAULT_SENDFILE_BUFFER_SIZE = 10240;
 	private static final String ERROR_NO_VIEW = "There is no view.";
 
+    // Lazy loaded properties (will only be initialized when FacesContext is available) -------------------------------
+    
+    private static String faceletsSuffix;
+    
 	// Constructors ---------------------------------------------------------------------------------------------------
 
 	private FacesLocal() {
 		// Hide constructor.
 	}
+    
+    // Lazy init ------------------------------------------------------------------------------------------------------
+    
+    private static String getFaceletsSuffix(FacesContext context) {
+        if (faceletsSuffix == null) {
+            faceletsSuffix = coalesce(getInitParameter(context, ViewHandler.FACELETS_SUFFIX_PARAM_NAME), ViewHandler.DEFAULT_FACELETS_SUFFIX);
+        }
+
+        return faceletsSuffix;
+    }
 
 	// JSF general ----------------------------------------------------------------------------------------------------
 
@@ -230,7 +244,12 @@ public final class FacesLocal {
 
 		if (externalContext.getRequestPathInfo() == null) {
 			String path = externalContext.getRequestServletPath();
-			return path.substring(path.lastIndexOf('.'));
+            int suffixPos = path.lastIndexOf('.');
+            if (suffixPos > -1) {
+                return path.substring(suffixPos);
+            } else {
+                return getFaceletsSuffix(context);
+            }
 		}
 		else {
 			return externalContext.getRequestServletPath();


### PR DESCRIPTION
Fix index out of bounds error when getMapping of extensionless url.  As a mapping default, return facelets extension.

This should go towards omnifaces 3.x

I copied some of the changes from 4.x since we are still using 3.x and we haven't had time to upgrade to a higher Servlet version (we are on 4.0). 