### PR TITLE
Reflection: add optimized utility method getPropertyName instead of repeated code

### DIFF
--- a/src/main/java/org/omnifaces/el/ExpressionInspector.java
+++ b/src/main/java/org/omnifaces/el/ExpressionInspector.java
@@ -12,12 +12,12 @@
  */
 package org.omnifaces.el;
 
-import static java.beans.Introspector.decapitalize;
 import static org.omnifaces.el.MethodReference.NO_PARAMS;
 import static org.omnifaces.el.functions.Strings.capitalize;
 import static org.omnifaces.util.Beans.unwrapIfNecessary;
 import static org.omnifaces.util.Components.createValueExpression;
 import static org.omnifaces.util.Reflection.findMethod;
+import static org.omnifaces.util.Reflection.getPropertyName;
 
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -86,7 +86,7 @@ public final class ExpressionInspector {
         if (type != null && MethodExpression.class.isAssignableFrom(type)) {
             var methodReference = getMethodReference(inspectorElContext, valueExpression);
             var base = methodReference.getBase();
-            var property = decapitalize(methodReference.getName().replaceFirst("(get|is)", ""));
+            var property = getPropertyName(methodReference.getName());
             return new ValueReference(base, property);
         }
 
@@ -276,7 +276,7 @@ public final class ExpressionInspector {
     }
 
     static class FinalBaseHolder {
-        private Object base;
+        private final Object base;
 
         public FinalBaseHolder(Object base) {
             this.base = base;

--- a/src/main/java/org/omnifaces/el/FacesELResolver.java
+++ b/src/main/java/org/omnifaces/el/FacesELResolver.java
@@ -12,7 +12,6 @@
  */
 package org.omnifaces.el;
 
-import static java.beans.Introspector.decapitalize;
 import static org.omnifaces.util.Utils.isOneInstanceOf;
 import static org.omnifaces.util.Utils.startsWithOneOf;
 
@@ -21,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.el.ELContext;
@@ -28,6 +28,7 @@ import jakarta.el.ELResolver;
 import jakarta.el.PropertyNotFoundException;
 
 import org.omnifaces.util.Faces;
+import org.omnifaces.util.Reflection;
 
 /**
  * This EL resolver basically creates an implicit object <code>#{faces}</code> in EL scope.
@@ -58,14 +59,11 @@ public class FacesELResolver extends ELResolver {
                 continue;
             }
 
-            String name = method.getName();
+            String methodName = method.getName();
+            String propertyName = Reflection.getPropertyName(methodName);
 
-            if (startsWithOneOf(name, "get", "is")) {
-                String property = decapitalize(name.replaceFirst("(get|is)", ""));
-
-                if (!startsWithOneOf(property, "response", "session", "flash")) {
-                    FACES_PROPERTIES.put(property, method);
-                }
+            if ( ! Objects.equals(methodName,propertyName) && !startsWithOneOf(propertyName, "response", "session", "flash")) {
+                FACES_PROPERTIES.put(propertyName, method);
             }
         }
     }

--- a/src/main/java/org/omnifaces/util/Reflection.java
+++ b/src/main/java/org/omnifaces/util/Reflection.java
@@ -1011,4 +1011,74 @@ public final class Reflection {
         }
     }
 
+    // Properties ---------------------------------------------------------------------------------------------------------
+
+    /**
+     * Internal utility to retrieve the index of the string after
+     * the usual prefix (get/is) of the accessor Method
+     * @return the index of the string array after the getter method prefix, -1 if not found
+     * @since 4.6
+     */
+    private static int propertyNameIndexOf(final char[] methodName) {
+        // todo: if we add an OR with methodName[0] == 's' when can support also setter methods
+        if ( methodName.length > 3 && methodName[0] == 'g' && methodName[1] == 'e' && methodName[2] == 't' ) {
+            return 3;
+        }
+        else if ( methodName.length > 2 && methodName[0] == 'i' && methodName[1] == 's' ) {
+            return 2;
+        }
+        else {
+            return -1;
+        }
+    }
+
+    /**
+     * @param method the accessor {@link Method}
+     * @return true if the passed {@link Method} is an accessor Method (it's name starts with "get" or "is")
+     * @since 4.6
+     */
+    public static boolean isGetterMethod(Method method) {
+        requireNonNull(method);
+        return propertyNameIndexOf(method.getName().toCharArray()) > -1;
+    }
+
+    /**
+     * Given a getter {@link Method}, e.g. {@code getName()} or {@code isCompleted()}, return the name
+     * of the "corresponding" property based on the Java standard style of programming.
+     *
+     * @param method the accessor {@link Method}
+     * @return the name of the property corresponding to the passed getter {@link Method}
+     * @see Introspector#decapitalize(String)
+     * @since 4.6
+     */
+    public static String getPropertyName(Method method) {
+        return getPropertyName(method.getName());
+    }
+
+    /**
+     * Given a getter method name, e.g. "getName" or "isCompleted", return the name
+     * of the "corresponding" property based on the Java standard style of programming.
+     *
+     * @param methodName the name of the accessor {@link Method}
+     * @return the name of the property corresponding to the passed Method's name,
+     * the passed methodName if it's not a getter Method
+     * @see Introspector#decapitalize(String)
+     * @since 4.6
+     */
+    public static String getPropertyName(String methodName) {
+        if (isEmpty(methodName)) return methodName;
+
+        final char[] chars = methodName.toCharArray();
+
+        final int indexOf = propertyNameIndexOf(chars);
+
+        if ( indexOf == -1 ) {
+            return methodName;
+        }
+
+        final String nameNoPrefix = new String(chars, indexOf, chars.length-indexOf);
+
+        return Introspector.decapitalize(nameNoPrefix);
+    }
+
 }


### PR DESCRIPTION
`FacesELResolver` initialization and `ExpressionInspector` both 
use a variant of the same copy/pasted code
which is also very slow because internally Java create 
a new Pattern + Matcher on the fly 

`FacesELResolver` initialization is heavily impacted because 
the replace is inside a loop with many items

I tried to do my best to create an optimized and reusable utiility method
inside `Reflection` utility class.

Sorry for the 4.x PR but 
I don't have the 2.x and 3.x branch in my fork and 
I don't know how to fork them again
