### PR TITLE
Update vdldoc-maven-plugin to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,14 +530,7 @@
             <plugin>
                 <groupId>com.github.matinh.vdldoc</groupId>
                 <artifactId>vdldoc-maven-plugin</artifactId>
-                <version>2.1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.omnifaces</groupId>
-                        <artifactId>vdldoc</artifactId>
-                        <version>4.0</version>
-                    </dependency>
-                </dependencies>
+                <version>2.3</version>
                 <executions>
                     <execution>
                         <id>generate-vdldoc</id>


### PR DESCRIPTION
Update vdldoc-maven-plugin to recent version 2.3, which includes an update to Vdldoc 4.0.

This update requires at least JDK17 and Maven 3.9x to build OmniFaces.