### PR TITLE
fix #1004 Beans#getManager() is slow

### DIFF
--- a/src/main/java/org/omnifaces/ApplicationListener.java
+++ b/src/main/java/org/omnifaces/ApplicationListener.java
@@ -41,6 +41,7 @@ import org.omnifaces.facesviews.FacesViews;
 import org.omnifaces.filter.FacesExceptionFilter;
 import org.omnifaces.resourcehandler.GraphicResource;
 import org.omnifaces.resourcehandler.ViewResourceHandler;
+import org.omnifaces.util.Beans;
 import org.omnifaces.util.Faces;
 import org.omnifaces.util.Servlets;
 import org.omnifaces.util.cache.CacheInitializer;
@@ -61,6 +62,8 @@ import org.omnifaces.util.cache.CacheInitializer;
  * <li>Register {@link Sse} endpoint if necessary.
  * <li>Register {@link ScriptErrorHandler} servlet if necessary.
  * </ol>
+ * <p>
+ * When the servlet context is destroyed, this forgets the CDI bean manager which {@link Beans} has remembered for this web application.
  * <p>
  * This is invoked <strong>after</strong> {@link ApplicationInitializer} and <strong>before</strong> {@link ApplicationProcessor}. If any exception is thrown,
  * then the deployment will fail, unless the {@value OmniFaces#PARAM_NAME_SKIP_DEPLOYMENT_EXCEPTION} context parameter is set to <code>true</code>, it will then
@@ -122,6 +125,11 @@ public class ApplicationListener extends DefaultServletContextListener {
         finally {
             Faces.setContext(null);
         }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+        Beans.forgetManager();
     }
 
     private static void checkFacesAvailable() {

--- a/src/main/java/org/omnifaces/util/Beans.java
+++ b/src/main/java/org/omnifaces/util/Beans.java
@@ -119,15 +119,11 @@ public final class Beans {
 
     };
 
-    // Obtaining the bean manager from CDI.current() is relatively expensive in at least Weld, which resolves it based on the class which invoked CDI, and
-    // therefore walks the entire stack trace of the current thread on every single call. As OmniFaces obtains it on nearly every invocation below, and thus
-    // many times per request, it is remembered here. Weld's outcome depends on the bean archive of the caller, which is this class, so the class loader is
-    // the correct key. Only the last one is remembered, because there is in the by far most common case only one, and this way the bean manager of an
-    // undeployed web application is never retained any longer than until the next call from another one.
-    private record CachedManager(ClassLoader classLoader, BeanManager manager) {
-    }
+    // Obtaining the bean manager is relatively expensive in at least Weld, so it is remembered, but only when this class is loaded by the web application's own
+    // class loader, as it would otherwise both retain and hand out the bean manager of a foreign web application.
+    private static final ClassLoader CLASS_LOADER = Beans.class.getClassLoader();
 
-    private static volatile CachedManager cachedManager;
+    private static volatile BeanManager cachedManager;
 
     // Constructors ---------------------------------------------------------------------------------------------------
 
@@ -138,25 +134,23 @@ public final class Beans {
     // Utility --------------------------------------------------------------------------------------------------------
 
     /**
-     * Returns the CDI bean manager. Once obtained, it is remembered for the context class loader of the current thread, as obtaining it is a relatively
-     * expensive task in some CDI implementations.
+     * Returns the CDI bean manager. Once obtained, it is remembered as long as this class is loaded by the web application's own class loader, as obtaining it
+     * is a relatively expensive task in some CDI implementations.
      *
      * @return The CDI bean manager.
      * @since 2.0
      * @see CDI#getBeanManager()
      */
     public static BeanManager getManager() {
-        var classLoader = Thread.currentThread().getContextClassLoader();
-        var cached = cachedManager;
-
-        if (cached != null && cached.classLoader() == classLoader) {
-            return cached.manager();
+        if (Thread.currentThread().getContextClassLoader() != CLASS_LOADER) {
+            return lookupManager();
         }
 
-        var manager = lookupManager();
+        var manager = cachedManager;
 
-        if (manager != null) { // An absent bean manager, e.g. when the CDI container hasn't been booted yet, must not be remembered.
-            cachedManager = new CachedManager(classLoader, manager);
+        if (manager == null) {
+            manager = lookupManager();
+            cachedManager = manager;
         }
 
         return manager;

--- a/src/main/java/org/omnifaces/util/Beans.java
+++ b/src/main/java/org/omnifaces/util/Beans.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -119,11 +120,9 @@ public final class Beans {
 
     };
 
-    // Obtaining the bean manager is relatively expensive in at least Weld, so it is remembered, but only when this class is loaded by the web application's own
-    // class loader, as it would otherwise both retain and hand out the bean manager of a foreign web application.
-    private static final ClassLoader CLASS_LOADER = Beans.class.getClassLoader();
-
-    private static volatile BeanManager cachedManager;
+    // The web application is identified by the context class loader of the current thread. Beware that this is not necessarily the class loader which loaded
+    // this class, as e.g. Liberty puts a per-application wrapper around it.
+    private static final Map<ClassLoader, BeanManager> CACHED_MANAGERS = new ConcurrentHashMap<>();
 
     // Constructors ---------------------------------------------------------------------------------------------------
 
@@ -134,26 +133,46 @@ public final class Beans {
     // Utility --------------------------------------------------------------------------------------------------------
 
     /**
-     * Returns the CDI bean manager. Once obtained, it is remembered as long as this class is loaded by the web application's own class loader, as obtaining it
-     * is a relatively expensive task in some CDI implementations.
+     * Returns the CDI bean manager. Once obtained, it is remembered for the web application at hand until it is destroyed, as obtaining it is a relatively
+     * expensive task in some CDI implementations.
      *
      * @return The CDI bean manager.
      * @since 2.0
      * @see CDI#getBeanManager()
      */
     public static BeanManager getManager() {
-        if (Thread.currentThread().getContextClassLoader() != CLASS_LOADER) {
+        var classLoader = Thread.currentThread().getContextClassLoader();
+
+        if (classLoader == null) {
             return lookupManager();
         }
 
-        var manager = cachedManager;
+        var manager = CACHED_MANAGERS.get(classLoader);
 
         if (manager == null) {
             manager = lookupManager();
-            cachedManager = manager;
+
+            if (manager != null) {
+                CACHED_MANAGERS.put(classLoader, manager);
+            }
         }
 
         return manager;
+    }
+
+    /**
+     * Forgets the CDI bean manager which was remembered for the context class loader of the current thread, if any. This is invoked by the OmniFaces
+     * application listener when the web application is being destroyed.
+     *
+     * @since 5.5.4
+     * @see #getManager()
+     */
+    public static void forgetManager() {
+        var classLoader = Thread.currentThread().getContextClassLoader();
+
+        if (classLoader != null) {
+            CACHED_MANAGERS.remove(classLoader);
+        }
     }
 
     private static BeanManager lookupManager() {

--- a/src/main/java/org/omnifaces/util/Beans.java
+++ b/src/main/java/org/omnifaces/util/Beans.java
@@ -119,6 +119,16 @@ public final class Beans {
 
     };
 
+    // Obtaining the bean manager from CDI.current() is relatively expensive in at least Weld, which resolves it based on the class which invoked CDI, and
+    // therefore walks the entire stack trace of the current thread on every single call. As OmniFaces obtains it on nearly every invocation below, and thus
+    // many times per request, it is remembered here. Weld's outcome depends on the bean archive of the caller, which is this class, so the class loader is
+    // the correct key. Only the last one is remembered, because there is in the by far most common case only one, and this way the bean manager of an
+    // undeployed web application is never retained any longer than until the next call from another one.
+    private record CachedManager(ClassLoader classLoader, BeanManager manager) {
+    }
+
+    private static volatile CachedManager cachedManager;
+
     // Constructors ---------------------------------------------------------------------------------------------------
 
     private Beans() {
@@ -128,13 +138,31 @@ public final class Beans {
     // Utility --------------------------------------------------------------------------------------------------------
 
     /**
-     * Returns the CDI bean manager.
+     * Returns the CDI bean manager. Once obtained, it is remembered for the context class loader of the current thread, as obtaining it is a relatively
+     * expensive task in some CDI implementations.
      *
      * @return The CDI bean manager.
      * @since 2.0
      * @see CDI#getBeanManager()
      */
     public static BeanManager getManager() {
+        var classLoader = Thread.currentThread().getContextClassLoader();
+        var cached = cachedManager;
+
+        if (cached != null && cached.classLoader() == classLoader) {
+            return cached.manager();
+        }
+
+        var manager = lookupManager();
+
+        if (manager != null) { // An absent bean manager, e.g. when the CDI container hasn't been booted yet, must not be remembered.
+            cachedManager = new CachedManager(classLoader, manager);
+        }
+
+        return manager;
+    }
+
+    private static BeanManager lookupManager() {
         try {
             return CDI.current().getBeanManager();
         }

--- a/src/test/java/org/omnifaces/test/util/beans/BeansIT.java
+++ b/src/test/java/org/omnifaces/test/util/beans/BeansIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.test.util.beans;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+import org.omnifaces.test.OmniFacesIT;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * The bean manager is obtained only once per web application, which relies on OmniFaces being loaded by the very class loader which is also the context class
+ * loader of the request thread, as is the case when it sits in the <code>/WEB-INF/lib</code> of the web application.
+ */
+public class BeansIT extends OmniFacesIT {
+
+    @FindBy(id = "classLoaderOwnedByWebApp")
+    private WebElement classLoaderOwnedByWebApp;
+
+    @FindBy(id = "managerRemembered")
+    private WebElement managerRemembered;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return createWebArchive(BeansIT.class);
+    }
+
+    @Test
+    void test() {
+        assertEquals("true", classLoaderOwnedByWebApp.getText(), "OmniFaces is loaded by the context class loader of the request thread");
+        assertEquals("true", managerRemembered.getText(), "bean manager is the same instance during the same request");
+
+        refresh();
+
+        assertEquals("true", managerRemembered.getText(), "bean manager is still the same instance during the next request");
+    }
+
+}

--- a/src/test/java/org/omnifaces/test/util/beans/BeansIT.java
+++ b/src/test/java/org/omnifaces/test/util/beans/BeansIT.java
@@ -22,13 +22,13 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 /**
- * The bean manager is obtained only once per web application, which relies on OmniFaces being loaded by the very class loader which is also the context class
- * loader of the request thread, as is the case when it sits in the <code>/WEB-INF/lib</code> of the web application.
+ * The bean manager is obtained only once per web application, which is identified by the context class loader of the request thread. This relies on that class
+ * loader being the same object for every request of the same web application, no matter which thread of the pool serves it.
  */
 public class BeansIT extends OmniFacesIT {
 
-    @FindBy(id = "classLoaderOwnedByWebApp")
-    private WebElement classLoaderOwnedByWebApp;
+    @FindBy(id = "contextClassLoaderStable")
+    private WebElement contextClassLoaderStable;
 
     @FindBy(id = "managerRemembered")
     private WebElement managerRemembered;
@@ -40,12 +40,11 @@ public class BeansIT extends OmniFacesIT {
 
     @Test
     void test() {
-        assertEquals("true", classLoaderOwnedByWebApp.getText(), "OmniFaces is loaded by the context class loader of the request thread");
-        assertEquals("true", managerRemembered.getText(), "bean manager is the same instance during the same request");
-
-        refresh();
-
-        assertEquals("true", managerRemembered.getText(), "bean manager is still the same instance during the next request");
+        for (var request = 1; request <= 4; request++) {
+            assertEquals("true", contextClassLoaderStable.getText(), "context class loader is the same instance during request " + request);
+            assertEquals("true", managerRemembered.getText(), "bean manager is the same instance during request " + request);
+            refresh();
+        }
     }
 
 }

--- a/src/test/java/org/omnifaces/test/util/beans/BeansITBean.java
+++ b/src/test/java/org/omnifaces/test/util/beans/BeansITBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.test.util.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Named;
+
+import org.omnifaces.util.Beans;
+
+@Named
+@ApplicationScoped
+public class BeansITBean {
+
+    private BeanManager manager;
+
+    public boolean isClassLoaderOwnedByWebApp() {
+        return Thread.currentThread().getContextClassLoader() == Beans.class.getClassLoader();
+    }
+
+    public boolean isManagerRemembered() {
+        var currentManager = Beans.getManager();
+
+        if (manager == null) {
+            manager = currentManager;
+        }
+
+        return manager == currentManager;
+    }
+
+}

--- a/src/test/java/org/omnifaces/test/util/beans/BeansITBean.java
+++ b/src/test/java/org/omnifaces/test/util/beans/BeansITBean.java
@@ -22,10 +22,17 @@ import org.omnifaces.util.Beans;
 @ApplicationScoped
 public class BeansITBean {
 
+    private ClassLoader contextClassLoader;
     private BeanManager manager;
 
-    public boolean isClassLoaderOwnedByWebApp() {
-        return Thread.currentThread().getContextClassLoader() == Beans.class.getClassLoader();
+    public boolean isContextClassLoaderStable() {
+        var currentContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        if (contextClassLoader == null) {
+            contextClassLoader = currentContextClassLoader;
+        }
+
+        return contextClassLoader == currentContextClassLoader;
     }
 
     public boolean isManagerRemembered() {

--- a/src/test/java/org/omnifaces/util/BeansGetManagerTest.java
+++ b/src/test/java/org/omnifaces/util/BeansGetManagerTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.util;
+
+import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Obtaining the bean manager is not necessarily cheap. Weld resolves it based on the class which invoked {@link CDI}, and therefore walks the entire stack
+ * trace of the current thread on every single {@link CDI#getBeanManager()} call, see <code>org.jboss.weld.AbstractCDI#getCallingClassName()</code>. On top of
+ * that, {@link CDI#current()} instantiates a brand new CDI object on every call in a servlet environment, see
+ * <code>org.jboss.weld.environment.servlet.WeldProvider</code>, and the CDI API itself invokes <code>CDIProvider#getCDI()</code> twice per
+ * {@link CDI#current()} call. As OmniFaces obtains the bean manager on nearly every {@link Beans} invocation, and thus many times per request, this is
+ * measurable in Weld 6. The tests below therefore count how often the CDI API is actually consulted, which is a deterministic measure, as opposed to elapsed
+ * time.
+ */
+class BeansGetManagerTest {
+
+    private static final String JNDI_NAME_BEAN_MANAGER = "java:comp/BeanManager";
+
+    private ClassLoader originalClassLoader;
+    private Map<ClassLoader, BeanManager> beanManagersPerClassLoader;
+    private AtomicInteger beanManagerLookups;
+    private BeanManager beanManager;
+
+    @BeforeEach
+    void setUp() {
+        originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+        // Every test runs in its own class loader so that it can never observe the bean manager which another test has left behind.
+        Thread.currentThread().setContextClassLoader(newWebAppClassLoader());
+
+        beanManagersPerClassLoader = new HashMap<>();
+        beanManagerLookups = new AtomicInteger();
+        beanManager = beanManagerOf(Thread.currentThread().getContextClassLoader());
+        setCDIProvider(mockCDI(this::beanManagerOf));
+    }
+
+    @AfterEach
+    void tearDown() {
+        Thread.currentThread().setContextClassLoader(originalClassLoader);
+        CDIProviderResetter.reset();
+        System.clearProperty(INITIAL_CONTEXT_FACTORY);
+        TestInitialContextFactory.context = null;
+    }
+
+    @Test
+    void managerIsObtainedFromCDI() {
+        assertSame(beanManager, Beans.getManager());
+    }
+
+    /**
+     * This is the actual regression test: the CDI API must be consulted only once, because implementations such as Weld walk the stack trace of the current
+     * thread on every single call.
+     */
+    @Test
+    void managerIsObtainedFromCDIOnlyOnce() {
+        for (var i = 0; i < 100; i++) {
+            assertSame(beanManager, Beans.getManager());
+        }
+
+        assertEquals(1, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted only once for the same class loader");
+    }
+
+    /**
+     * OmniFaces may be deployed in a class loader which is shared by multiple web applications, e.g. when it sits in the <code>/lib</code> of an EAR. Each of
+     * them has its own bean manager, so the outcome may never be shared among class loaders.
+     */
+    @Test
+    void managerIsNotSharedAmongClassLoaders() {
+        var thisWebAppClassLoader = Thread.currentThread().getContextClassLoader();
+        var otherWebAppClassLoader = newWebAppClassLoader();
+        var managerOfThisWebApp = Beans.getManager();
+
+        Thread.currentThread().setContextClassLoader(otherWebAppClassLoader);
+        var managerOfOtherWebApp = Beans.getManager();
+        assertNotSame(managerOfThisWebApp, managerOfOtherWebApp);
+
+        Thread.currentThread().setContextClassLoader(thisWebAppClassLoader);
+        assertSame(managerOfThisWebApp, Beans.getManager());
+
+        Thread.currentThread().setContextClassLoader(otherWebAppClassLoader);
+        assertSame(managerOfOtherWebApp, Beans.getManager());
+    }
+
+    /**
+     * An absent bean manager, as can happen when the CDI container has not been booted yet, may never be remembered, otherwise the bean manager would stay
+     * absent for the remainder of the application's lifetime.
+     */
+    @Test
+    void absentManagerIsNotRemembered() {
+        var available = new AtomicBoolean(false);
+        setCDIProvider(mockCDI(classLoader -> available.get() ? beanManagerOf(classLoader) : null));
+
+        assertNull(Beans.getManager());
+
+        available.set(true);
+        assertSame(beanManager, Beans.getManager());
+    }
+
+    /**
+     * This merely guards the existing JNDI fallback for environments where <code>CDI.current()</code> is unavailable, e.g. Tomcat without any CDI
+     * implementation deployed as a library.
+     */
+    @Test
+    void managerIsObtainedFromJNDIWhenCDIIsUnavailable() throws NamingException {
+        var jndiContext = mock(Context.class);
+        when(jndiContext.lookup(JNDI_NAME_BEAN_MANAGER)).thenReturn(beanManager);
+        TestInitialContextFactory.context = jndiContext;
+        System.setProperty(INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class.getName());
+        setCDIProvider(null);
+
+        assertSame(beanManager, Beans.getManager());
+    }
+
+    // Helpers --------------------------------------------------------------------------------------------------------
+
+    private static ClassLoader newWebAppClassLoader() {
+        return new URLClassLoader("webapp", new URL[0], BeansGetManagerTest.class.getClassLoader());
+    }
+
+    private BeanManager beanManagerOf(ClassLoader classLoader) {
+        return beanManagersPerClassLoader.computeIfAbsent(classLoader, key -> mock(BeanManager.class));
+    }
+
+    /**
+     * Returns a CDI mock which resolves the bean manager the same way as Weld does; based on the caller, which it obtains from the stack trace of the current
+     * thread on every single call.
+     */
+    @SuppressWarnings("unchecked")
+    private CDI<Object> mockCDI(Function<ClassLoader, BeanManager> beanManagerResolver) {
+        CDI<Object> mockedCDI = mock(CDI.class);
+        when(mockedCDI.getBeanManager()).thenAnswer(invocation -> {
+            beanManagerLookups.incrementAndGet();
+            getCallingClassName();
+            return beanManagerResolver.apply(Thread.currentThread().getContextClassLoader());
+        });
+        return mockedCDI;
+    }
+
+    /**
+     * This is in essence what <code>org.jboss.weld.AbstractCDI#getCallingClassName()</code> does on every single {@link CDI#getBeanManager()} call.
+     */
+    private static String getCallingClassName() {
+        for (var element : Thread.currentThread().getStackTrace()) {
+            if (Beans.class.getName().equals(element.getClassName())) {
+                return element.getClassName();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Installs a CDI provider returning the given CDI instance, or one throwing {@link IllegalStateException} as the CDI API itself does when there is none,
+     * when the given CDI instance is <code>null</code>.
+     */
+    private static void setCDIProvider(CDI<Object> cdi) {
+        CDI.setCDIProvider(() -> {
+            if (cdi == null) {
+                throw new IllegalStateException("Unable to access CDI");
+            }
+
+            return cdi;
+        });
+    }
+
+    // Inner classes --------------------------------------------------------------------------------------------------
+
+    /**
+     * The CDI API does not offer any way to uninstall a programmatically set CDI provider, but the field holding it is protected static and thus accessible to
+     * subclasses, so that the JVM wide state of the CDI API can be left behind clean for other tests.
+     */
+    private abstract static class CDIProviderResetter extends CDI<Object> {
+
+        static void reset() {
+            configuredProvider = null;
+        }
+
+    }
+
+    /**
+     * Serves the mocked JNDI context to {@link javax.naming.InitialContext}.
+     */
+    public static class TestInitialContextFactory implements InitialContextFactory {
+
+        private static Context context;
+
+        @Override
+        public Context getInitialContext(Hashtable<?, ?> environment) {
+            return context;
+        }
+
+    }
+
+}

--- a/src/test/java/org/omnifaces/util/BeansGetManagerTest.java
+++ b/src/test/java/org/omnifaces/util/BeansGetManagerTest.java
@@ -14,6 +14,7 @@ package org.omnifaces.util;
 
 import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
@@ -43,8 +44,7 @@ import org.junit.jupiter.api.Test;
  * Obtaining the bean manager is not necessarily cheap. Weld resolves it based on the class which invoked {@link CDI}, and therefore walks the entire stack
  * trace of the current thread on every single {@link CDI#getBeanManager()} call. As OmniFaces obtains the bean manager on nearly every {@link Beans}
  * invocation, and thus many times per request, it may be obtained only once per web application. The tests below therefore count how often the CDI API is
- * actually consulted, which is a deterministic measure, as opposed to elapsed time. Each of them loads {@link Beans} in its own class loader, exactly like a
- * web application does, so that it can never observe the bean manager which another test has left behind.
+ * actually consulted, which is a deterministic measure, as opposed to elapsed time.
  */
 class BeansGetManagerTest {
 
@@ -53,12 +53,18 @@ class BeansGetManagerTest {
     private ClassLoader originalClassLoader;
     private Map<ClassLoader, BeanManager> beanManagersPerClassLoader;
     private AtomicInteger beanManagerLookups;
+    private BeanManager beanManager;
 
     @BeforeEach
     void setUp() {
         originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+        // Every test runs in its own class loader so that it can never observe the bean manager which another test has left behind.
+        Thread.currentThread().setContextClassLoader(newWebAppClassLoader());
+
         beanManagersPerClassLoader = new HashMap<>();
         beanManagerLookups = new AtomicInteger();
+        beanManager = beanManagerOf(Thread.currentThread().getContextClassLoader());
         setCDIProvider(mockCDI(this::beanManagerOf));
     }
 
@@ -72,9 +78,7 @@ class BeansGetManagerTest {
 
     @Test
     void managerIsObtainedFromCDI() {
-        var webApp = newClassLoader("webApp", originalClassLoader);
-
-        assertSame(beanManagerOf(webApp), getManager(webApp));
+        assertSame(beanManager, Beans.getManager());
     }
 
     /**
@@ -83,31 +87,59 @@ class BeansGetManagerTest {
      */
     @Test
     void managerIsObtainedFromCDIOnlyOnce() {
-        var webApp = newClassLoader("webApp", originalClassLoader);
-
         for (var i = 0; i < 100; i++) {
-            assertSame(beanManagerOf(webApp), getManager(webApp));
+            assertSame(beanManager, Beans.getManager());
         }
 
-        assertEquals(1, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted only once");
+        assertEquals(1, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted only once for the same class loader");
     }
 
     /**
-     * OmniFaces may sit in a class loader which is shared by multiple web applications, e.g. in the <code>/lib</code> of an EAR. Each of them has its own bean
-     * manager, so the outcome may then never be remembered, otherwise one web application would obtain the bean manager of another one, and the bean manager of
-     * an undeployed web application would be retained.
+     * OmniFaces may be deployed in a class loader which is shared by multiple web applications, e.g. when it sits in the <code>/lib</code> of an EAR. Each of
+     * them has its own bean manager, so the outcome may never be shared among class loaders.
      */
     @Test
-    void managerIsNotRememberedWhenClassLoaderIsShared() {
-        var earLib = newClassLoader("earLib", originalClassLoader);
-        var webAppA = newClassLoader("webAppA", earLib);
-        var webAppB = newClassLoader("webAppB", earLib);
+    void managerIsNotSharedAmongClassLoaders() {
+        var thisWebAppClassLoader = Thread.currentThread().getContextClassLoader();
+        var otherWebAppClassLoader = newWebAppClassLoader();
+        var managerOfThisWebApp = Beans.getManager();
 
-        assertSame(beanManagerOf(webAppA), getManager(earLib, webAppA));
-        assertSame(beanManagerOf(webAppB), getManager(earLib, webAppB));
-        assertSame(beanManagerOf(webAppA), getManager(earLib, webAppA));
+        Thread.currentThread().setContextClassLoader(otherWebAppClassLoader);
+        var managerOfOtherWebApp = Beans.getManager();
+        assertNotSame(managerOfThisWebApp, managerOfOtherWebApp);
 
-        assertEquals(3, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted on every call");
+        Thread.currentThread().setContextClassLoader(thisWebAppClassLoader);
+        assertSame(managerOfThisWebApp, Beans.getManager());
+
+        Thread.currentThread().setContextClassLoader(otherWebAppClassLoader);
+        assertSame(managerOfOtherWebApp, Beans.getManager());
+    }
+
+    /**
+     * The web application which the bean manager belongs to is identified by the context class loader, so when there is none, then there is nothing to remember
+     * it for.
+     */
+    @Test
+    void managerIsNotRememberedWithoutContextClassLoader() {
+        Thread.currentThread().setContextClassLoader(null);
+
+        assertSame(beanManagerOf(null), Beans.getManager());
+        assertSame(beanManagerOf(null), Beans.getManager());
+        assertEquals(2, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted on every call");
+    }
+
+    /**
+     * The bean manager of a web application which is being destroyed may not be retained, otherwise its class loader can never be garbage collected when
+     * OmniFaces sits in a class loader which outlives it, e.g. in the <code>/lib</code> of an EAR.
+     */
+    @Test
+    void managerIsForgottenWhenWebAppIsDestroyed() {
+        assertSame(beanManager, Beans.getManager());
+
+        Beans.forgetManager();
+
+        assertSame(beanManager, Beans.getManager());
+        assertEquals(2, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted again after the web application is destroyed");
     }
 
     /**
@@ -116,14 +148,13 @@ class BeansGetManagerTest {
      */
     @Test
     void absentManagerIsNotRemembered() {
-        var webApp = newClassLoader("webApp", originalClassLoader);
         var available = new AtomicBoolean(false);
         setCDIProvider(mockCDI(classLoader -> available.get() ? beanManagerOf(classLoader) : null));
 
-        assertNull(getManager(webApp));
+        assertNull(Beans.getManager());
 
         available.set(true);
-        assertSame(beanManagerOf(webApp), getManager(webApp));
+        assertSame(beanManager, Beans.getManager());
     }
 
     /**
@@ -132,70 +163,19 @@ class BeansGetManagerTest {
      */
     @Test
     void managerIsObtainedFromJNDIWhenCDIIsUnavailable() throws NamingException {
-        var webApp = newClassLoader("webApp", originalClassLoader);
         var jndiContext = mock(Context.class);
-        when(jndiContext.lookup(JNDI_NAME_BEAN_MANAGER)).thenReturn(beanManagerOf(webApp));
+        when(jndiContext.lookup(JNDI_NAME_BEAN_MANAGER)).thenReturn(beanManager);
         TestInitialContextFactory.context = jndiContext;
         System.setProperty(INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class.getName());
         setCDIProvider(null);
 
-        assertSame(beanManagerOf(webApp), getManager(webApp));
+        assertSame(beanManager, Beans.getManager());
     }
 
     // Helpers --------------------------------------------------------------------------------------------------------
 
-    /**
-     * Returns the bean manager as obtained by the {@link Beans} of the given class loader, while it is also the context class loader, which is exactly the
-     * situation of a web application having OmniFaces in its own <code>/WEB-INF/lib</code>.
-     */
-    private static BeanManager getManager(ClassLoader classLoader) {
-        return getManager(classLoader, classLoader);
-    }
-
-    /**
-     * Returns the bean manager as obtained by the {@link Beans} of the given class loader, while the given other class loader is the context class loader,
-     * which is exactly the situation of a web application having OmniFaces in a shared class loader.
-     */
-    private static BeanManager getManager(ClassLoader classLoader, ClassLoader contextClassLoader) {
-        Thread.currentThread().setContextClassLoader(contextClassLoader);
-
-        try {
-            return (BeanManager) Class.forName(Beans.class.getName(), true, classLoader).getMethod("getManager").invoke(null);
-        }
-        catch (ReflectiveOperationException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    /**
-     * Returns a class loader which loads the OmniFaces classes itself, exactly like a web application does, and delegates all other classes to the given
-     * parent, so that the CDI API and the provider set on it remain shared.
-     */
-    private static ClassLoader newClassLoader(String name, ClassLoader parent) {
-        return new URLClassLoader(name, new URL[] { Beans.class.getProtectionDomain().getCodeSource().getLocation() }, parent) {
-
-            @Override
-            protected Class<?> loadClass(String className, boolean resolve) throws ClassNotFoundException {
-                synchronized (getClassLoadingLock(className)) {
-                    if (findResource(className.replace('.', '/') + ".class") == null) {
-                        return super.loadClass(className, resolve);
-                    }
-
-                    var loadedClass = findLoadedClass(className);
-
-                    if (loadedClass == null) {
-                        loadedClass = findClass(className);
-                    }
-
-                    if (resolve) {
-                        resolveClass(loadedClass);
-                    }
-
-                    return loadedClass;
-                }
-            }
-
-        };
+    private static ClassLoader newWebAppClassLoader() {
+        return new URLClassLoader("webapp", new URL[0], BeansGetManagerTest.class.getClassLoader());
     }
 
     private BeanManager beanManagerOf(ClassLoader classLoader) {

--- a/src/test/java/org/omnifaces/util/BeansGetManagerTest.java
+++ b/src/test/java/org/omnifaces/util/BeansGetManagerTest.java
@@ -14,7 +14,6 @@ package org.omnifaces.util;
 
 import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
@@ -42,12 +41,10 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Obtaining the bean manager is not necessarily cheap. Weld resolves it based on the class which invoked {@link CDI}, and therefore walks the entire stack
- * trace of the current thread on every single {@link CDI#getBeanManager()} call, see <code>org.jboss.weld.AbstractCDI#getCallingClassName()</code>. On top of
- * that, {@link CDI#current()} instantiates a brand new CDI object on every call in a servlet environment, see
- * <code>org.jboss.weld.environment.servlet.WeldProvider</code>, and the CDI API itself invokes <code>CDIProvider#getCDI()</code> twice per
- * {@link CDI#current()} call. As OmniFaces obtains the bean manager on nearly every {@link Beans} invocation, and thus many times per request, this is
- * measurable in Weld 6. The tests below therefore count how often the CDI API is actually consulted, which is a deterministic measure, as opposed to elapsed
- * time.
+ * trace of the current thread on every single {@link CDI#getBeanManager()} call. As OmniFaces obtains the bean manager on nearly every {@link Beans}
+ * invocation, and thus many times per request, it may be obtained only once per web application. The tests below therefore count how often the CDI API is
+ * actually consulted, which is a deterministic measure, as opposed to elapsed time. Each of them loads {@link Beans} in its own class loader, exactly like a
+ * web application does, so that it can never observe the bean manager which another test has left behind.
  */
 class BeansGetManagerTest {
 
@@ -56,18 +53,12 @@ class BeansGetManagerTest {
     private ClassLoader originalClassLoader;
     private Map<ClassLoader, BeanManager> beanManagersPerClassLoader;
     private AtomicInteger beanManagerLookups;
-    private BeanManager beanManager;
 
     @BeforeEach
     void setUp() {
         originalClassLoader = Thread.currentThread().getContextClassLoader();
-
-        // Every test runs in its own class loader so that it can never observe the bean manager which another test has left behind.
-        Thread.currentThread().setContextClassLoader(newWebAppClassLoader());
-
         beanManagersPerClassLoader = new HashMap<>();
         beanManagerLookups = new AtomicInteger();
-        beanManager = beanManagerOf(Thread.currentThread().getContextClassLoader());
         setCDIProvider(mockCDI(this::beanManagerOf));
     }
 
@@ -81,41 +72,42 @@ class BeansGetManagerTest {
 
     @Test
     void managerIsObtainedFromCDI() {
-        assertSame(beanManager, Beans.getManager());
+        var webApp = newClassLoader("webApp", originalClassLoader);
+
+        assertSame(beanManagerOf(webApp), getManager(webApp));
     }
 
     /**
-     * This is the actual regression test: the CDI API must be consulted only once, because implementations such as Weld walk the stack trace of the current
+     * This is the actual regression test: the CDI API may be consulted only once, because implementations such as Weld walk the stack trace of the current
      * thread on every single call.
      */
     @Test
     void managerIsObtainedFromCDIOnlyOnce() {
+        var webApp = newClassLoader("webApp", originalClassLoader);
+
         for (var i = 0; i < 100; i++) {
-            assertSame(beanManager, Beans.getManager());
+            assertSame(beanManagerOf(webApp), getManager(webApp));
         }
 
-        assertEquals(1, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted only once for the same class loader");
+        assertEquals(1, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted only once");
     }
 
     /**
-     * OmniFaces may be deployed in a class loader which is shared by multiple web applications, e.g. when it sits in the <code>/lib</code> of an EAR. Each of
-     * them has its own bean manager, so the outcome may never be shared among class loaders.
+     * OmniFaces may sit in a class loader which is shared by multiple web applications, e.g. in the <code>/lib</code> of an EAR. Each of them has its own bean
+     * manager, so the outcome may then never be remembered, otherwise one web application would obtain the bean manager of another one, and the bean manager of
+     * an undeployed web application would be retained.
      */
     @Test
-    void managerIsNotSharedAmongClassLoaders() {
-        var thisWebAppClassLoader = Thread.currentThread().getContextClassLoader();
-        var otherWebAppClassLoader = newWebAppClassLoader();
-        var managerOfThisWebApp = Beans.getManager();
+    void managerIsNotRememberedWhenClassLoaderIsShared() {
+        var earLib = newClassLoader("earLib", originalClassLoader);
+        var webAppA = newClassLoader("webAppA", earLib);
+        var webAppB = newClassLoader("webAppB", earLib);
 
-        Thread.currentThread().setContextClassLoader(otherWebAppClassLoader);
-        var managerOfOtherWebApp = Beans.getManager();
-        assertNotSame(managerOfThisWebApp, managerOfOtherWebApp);
+        assertSame(beanManagerOf(webAppA), getManager(earLib, webAppA));
+        assertSame(beanManagerOf(webAppB), getManager(earLib, webAppB));
+        assertSame(beanManagerOf(webAppA), getManager(earLib, webAppA));
 
-        Thread.currentThread().setContextClassLoader(thisWebAppClassLoader);
-        assertSame(managerOfThisWebApp, Beans.getManager());
-
-        Thread.currentThread().setContextClassLoader(otherWebAppClassLoader);
-        assertSame(managerOfOtherWebApp, Beans.getManager());
+        assertEquals(3, beanManagerLookups.get(), "CDI#getBeanManager() must be consulted on every call");
     }
 
     /**
@@ -124,13 +116,14 @@ class BeansGetManagerTest {
      */
     @Test
     void absentManagerIsNotRemembered() {
+        var webApp = newClassLoader("webApp", originalClassLoader);
         var available = new AtomicBoolean(false);
         setCDIProvider(mockCDI(classLoader -> available.get() ? beanManagerOf(classLoader) : null));
 
-        assertNull(Beans.getManager());
+        assertNull(getManager(webApp));
 
         available.set(true);
-        assertSame(beanManager, Beans.getManager());
+        assertSame(beanManagerOf(webApp), getManager(webApp));
     }
 
     /**
@@ -139,19 +132,70 @@ class BeansGetManagerTest {
      */
     @Test
     void managerIsObtainedFromJNDIWhenCDIIsUnavailable() throws NamingException {
+        var webApp = newClassLoader("webApp", originalClassLoader);
         var jndiContext = mock(Context.class);
-        when(jndiContext.lookup(JNDI_NAME_BEAN_MANAGER)).thenReturn(beanManager);
+        when(jndiContext.lookup(JNDI_NAME_BEAN_MANAGER)).thenReturn(beanManagerOf(webApp));
         TestInitialContextFactory.context = jndiContext;
         System.setProperty(INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class.getName());
         setCDIProvider(null);
 
-        assertSame(beanManager, Beans.getManager());
+        assertSame(beanManagerOf(webApp), getManager(webApp));
     }
 
     // Helpers --------------------------------------------------------------------------------------------------------
 
-    private static ClassLoader newWebAppClassLoader() {
-        return new URLClassLoader("webapp", new URL[0], BeansGetManagerTest.class.getClassLoader());
+    /**
+     * Returns the bean manager as obtained by the {@link Beans} of the given class loader, while it is also the context class loader, which is exactly the
+     * situation of a web application having OmniFaces in its own <code>/WEB-INF/lib</code>.
+     */
+    private static BeanManager getManager(ClassLoader classLoader) {
+        return getManager(classLoader, classLoader);
+    }
+
+    /**
+     * Returns the bean manager as obtained by the {@link Beans} of the given class loader, while the given other class loader is the context class loader,
+     * which is exactly the situation of a web application having OmniFaces in a shared class loader.
+     */
+    private static BeanManager getManager(ClassLoader classLoader, ClassLoader contextClassLoader) {
+        Thread.currentThread().setContextClassLoader(contextClassLoader);
+
+        try {
+            return (BeanManager) Class.forName(Beans.class.getName(), true, classLoader).getMethod("getManager").invoke(null);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Returns a class loader which loads the OmniFaces classes itself, exactly like a web application does, and delegates all other classes to the given
+     * parent, so that the CDI API and the provider set on it remain shared.
+     */
+    private static ClassLoader newClassLoader(String name, ClassLoader parent) {
+        return new URLClassLoader(name, new URL[] { Beans.class.getProtectionDomain().getCodeSource().getLocation() }, parent) {
+
+            @Override
+            protected Class<?> loadClass(String className, boolean resolve) throws ClassNotFoundException {
+                synchronized (getClassLoadingLock(className)) {
+                    if (findResource(className.replace('.', '/') + ".class") == null) {
+                        return super.loadClass(className, resolve);
+                    }
+
+                    var loadedClass = findLoadedClass(className);
+
+                    if (loadedClass == null) {
+                        loadedClass = findClass(className);
+                    }
+
+                    if (resolve) {
+                        resolveClass(loadedClass);
+                    }
+
+                    return loadedClass;
+                }
+            }
+
+        };
     }
 
     private BeanManager beanManagerOf(ClassLoader classLoader) {

--- a/src/test/resources/org.omnifaces.test.util.beans/BeansIT.xhtml
+++ b/src/test/resources/org.omnifaces.test.util.beans/BeansIT.xhtml
@@ -19,7 +19,7 @@
     <h:head />
 
     <h:body>
-        <h:outputText id="classLoaderOwnedByWebApp" value="#{beansITBean.classLoaderOwnedByWebApp}" />
+        <h:outputText id="contextClassLoaderStable" value="#{beansITBean.contextClassLoaderStable}" />
         <h:outputText id="managerRemembered" value="#{beansITBean.managerRemembered}" />
     </h:body>
 </html>

--- a/src/test/resources/org.omnifaces.test.util.beans/BeansIT.xhtml
+++ b/src/test/resources/org.omnifaces.test.util.beans/BeansIT.xhtml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright OmniFaces
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+    the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+>
+    <h:head />
+
+    <h:body>
+        <h:outputText id="classLoaderOwnedByWebApp" value="#{beansITBean.classLoaderOwnedByWebApp}" />
+        <h:outputText id="managerRemembered" value="#{beansITBean.managerRemembered}" />
+    </h:body>
+</html>


### PR DESCRIPTION
on Weld 6: CDI.current().getBeanManager() walks the thread's stack trace on every single call